### PR TITLE
Remove android support from xamarin integration instructions

### DIFF
--- a/android/pnddocs/xamarin-android.md
+++ b/android/pnddocs/xamarin-android.md
@@ -4,9 +4,8 @@
 
 Right-click on your Android project target.  
 1. Click "Add" and "Add NuGet Packages…".  
-2. If your application is using AndroidX, and only Xamarin, search for **"pendo-sdk-androidx"**.
-3. For Android support and Xamarin, search **"pendo-sdk-android"**.  
-4. Click "Add Package".
+2. Search for **"pendo-sdk-androidx"**.
+3. Click "Add Package".
 
 ##### Review Android minimum requirements (compileSdkVersion, minSdkVersion, etc.) <a href="https://support.pendo.io/hc/en-us/articles/4404197902235" target="_blank">here.</a>
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/44)
<!-- Reviewable:end -->
