### PR TITLE
APP-148196: Add Session Replay performance benchmarks

### DIFF
--- a/benchmarks/NativePerformanceBenchmarks.md
+++ b/benchmarks/NativePerformanceBenchmarks.md
@@ -20,7 +20,7 @@ When Session Replay is enabled, additional resources are used to capture, compre
 |                | Memory Impact | Battery Impact | CPU Impact | Network (outgoing)\* |
 |     :---:      |     :---:     |     :---:      |   :---:    |        :---:         |
 |    Android     |  (~) +14MB    |    Moderate    |  Moderate  |    (~) +2.5MB        |
-|      iOS       |  Negligible   |   Negligible   |    Low     |    (~) +5.1MB        |
+|      iOS       |   (~) +2MB    |   Negligible   |    Low     |    (~) +6.4MB        |
 
 <b>\*</b> Additional outgoing traffic compared to SDK without Session Replay, measured over ~8-minute sessions on a physical device. Actual usage scales with session length and screen complexity.
 

--- a/benchmarks/NativePerformanceBenchmarks.md
+++ b/benchmarks/NativePerformanceBenchmarks.md
@@ -13,6 +13,17 @@ These measurements of the SDK are captured using Pendo’s testing applications 
 <br>
 <b>\*\*</b> Slight CPU impact may occur during app launch or UI-intensive operations.
 
+### Session Replay performance
+
+When Session Replay is enabled, additional resources are used to capture, compress, and upload session recordings. Frame rendering performance (frame times and jank rate) is unaffected across all tested configurations.
+
+|                | Memory Impact | Battery Impact | CPU Impact | Network (outgoing)\* |
+|     :---:      |     :---:     |     :---:      |   :---:    |        :---:         |
+|    Android     |  (~) +14MB    |    Moderate    |  Moderate  |    (~) +2.5MB        |
+|      iOS       |  Negligible   |   Negligible   |    Low     |    (~) +5.1MB        |
+
+<b>\*</b> Additional outgoing traffic compared to SDK without Session Replay, measured over ~8-minute sessions on a physical device. Actual usage scales with session length and screen complexity.
+
 ### SDK network usage
 
 The Pendo SDK network traffic consists of two parts:


### PR DESCRIPTION
## Summary

- Adds a new **Session Replay performance** section to `NativePerformanceBenchmarks.md`
- Data sourced from internal benchmarks: iOS SDK 3.12.0 (iPhone 12, iOS 26.3) and Android SDK 3.11.3 (physical device)
- Covers memory, battery, CPU, and outgoing network impact for SR vs. SDK-only baseline
- Key message: frame rendering is unaffected; overhead is proportional to SR capture/upload activity

## Changes

| Platform | Memory | Battery | CPU | Network (outgoing) |
|---|---|---|---|---|
| Android | +~14MB | Moderate | Moderate | +~2.5MB/session |
| iOS | Negligible | Negligible | Low | +~5.1MB/session |

## Test plan

- [ ] Verify table renders correctly in GitHub markdown preview
- [ ] Confirm numbers match internal benchmark reports (iOS: [SDK 3.12.0 Benchmark](https://pendo-io.atlassian.net/wiki/spaces/ENG/pages/4661411854), Android: [SDK 3.11.3 Benchmark](https://pendo-io.atlassian.net/wiki/spaces/ENG/pages/4621795360))
- [ ] Review footnote wording for accuracy

Resolves [APP-148196](https://pendo-io.atlassian.net/browse/APP-148196)

[APP-148196]: https://pendo-io.atlassian.net/browse/APP-148196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/309)
<!-- Reviewable:end -->
