### PR TITLE
APP-146513: Remove List Elements limitation from SwiftUI docs

### DIFF
--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -297,23 +297,11 @@ b. If the tagged Page identifier such as `retroactiveScreenId` or `swiftUIIdenti
 2. **Tagging**:<br>
  Pendo's Feature tagging relies heavily on iOS accessibility services to gather information like accessibilityHint, accessibilityIdentifier, accessibilityLabel, and user interactions. While iOS typically provides these accessibility elements by default, there might be instances where UI elements are not automatically tagged as expected by the Pendo SDK. In such cases, you can use the pendoRecognizeClickAnalytics() modifier. This API helps by creating an accessibility element, combining its children, and marking it as userInteractionEnabled. This allows Pendo to correctly identify the element as taggable and record click analytics for it.
 
-3. **List Elements**:<br> 
-SwiftUI's `List` and `ForEach` are used to create dynamic lists. Under the hood, SwiftUI's `List` uses a `UICollectionView`, allowing the Pendo SDK to tag individual list elements.
-Click analytics are recorded only for elements that are clickable.
-
-- **Automatic tracking**: When list rows are wrapped in a `Button` or `NavigationLink`, Pendo tracks clicks automatically. Clicks are also tracked when using the `.onChange` modifier with a `List` to handle selection changes. In these cases, we detect clicks via `collectionView:didSelectItemAtIndexPath:`.
-- **Manual intervention**: If you use gestures like `.onTapGesture`, the Pendo SDK might not record clicks. In such cases, you need to help Pendo recognize the interaction. You can use the `pendoRecognizeClickAnalytics()` API, or Apple's native accessibility modifiers:
-  ```swift
-  .accessibilityElement(children: .combine)
-  .accessibilityAddTraits([.isButton])
-  ```
-This ensures that Pendo can record click analytics for the element.
-
-4. **Container Views**: <br>
+3. **Container Views**: <br>
 Container views with `TapGestures` modifiers don't always generate underlying accessibility elements and may cause Pendo SDK to fail tagging them as clickable elements and collecting analytics. This is because such views are purely declarative and serve as instructions for their child elements.<br> 
 Examples of these views include `VStack`, `HStack`, `ZStack`, `LazyHStack`, `LazyVStack`, `LazyVGrid`, `GeometryReader`, and `LazyHGrid`. In that case we recommend using the `pendoRecognizeClickAnalytics()` API on the specific element to ensure interactions are properly recorded. 
 
-5. **UIContextMenu,Menu,.contextMenu**: <br>
+4. **UIContextMenu,Menu,.contextMenu**: <br>
  The UIContextMenu control is not supported in both Swift and SwiftUI. As a result, any interactions with context menus created using this control will not be tracked by the SDK.<br/>
 
 ## Developer documentation


### PR DESCRIPTION
## Summary
- Removed the **List Elements** limitation section from SwiftUI docs (`native-ios.md`)
- List cells with `.onTapGesture` are now automatically tracked by the SDK — the manual workaround (`pendoRecognizeClickAnalytics()` / accessibility traits) is no longer needed
- Renumbered remaining limitation items

## Test plan
- [ ] Verify the rendered markdown displays correctly on GitHub
- [ ] Confirm no broken links or formatting issues in the limitations section

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/311)
<!-- Reviewable:end -->
