### PR TITLE
APP-151465 Document new SwiftUI pendoTag API

### DIFF
--- a/api-documentation/native-ios-apis.md
+++ b/api-documentation/native-ios-apis.md
@@ -35,6 +35,7 @@
 ### View
 [View.pendoEnableSwiftUI](#viewpendoenableswiftui) ⇒ `void` <br>
 [View.pendoRecognizeClickAnalytics](#viewpendorecognizeclickanalytics) ⇒ `void` <br>
+[View.pendoTag](#viewpendotag) ⇒ `some View`<br>
 [View.trackPage](#viewtrackpage) ⇒ `some View`<br>
 
 ### NSNotifications
@@ -652,6 +653,70 @@ func pendoRecognizeClickAnalytics()-> some View;
 
 ```swift
 someView.pendoRecognizeClickAnalytics() -> some View;
+```
+</details>
+
+### `View.pendoTag`
+
+> [!NOTE]
+> Available from SDK 3.13 on iOS 13 and above.
+
+```swift
+func pendoTag(_ pendoTag: String) -> some View
+```
+
+>Attaches a unique identifier to a SwiftUI View so Pendo records clicks and guide interactions for it with the supplied tag. The modifier installs a transparent overlay over the modified view; any tap that lands inside the overlay's bounds is reported as a click on the tagged element, regardless of whether the underlying clickable control is SwiftUI- or UIKit-backed (`Button`, `Menu`, `.contextMenu`, `UIContextMenuInteraction`, `UIViewRepresentable`-wrapped `UIControl`, etc.).
+>
+>Use this API when Pendo's automatic feature-tagging does not uniquely identify the element you want to track, when you want a stable tag that is independent of localized text, or when you need to tag a container view (`VStack`, `HStack`, `ZStack`, `LazyVGrid`, …) that has a tap gesture.
+>
+>**Nesting:** when multiple `.pendoTag` modifiers overlap, the most specific (smallest-area / front-most) tag wins.
+>
+>**Empty strings** are ignored — passing `""` is treated the same as not applying the modifier.
+>
+>The overlay is fully transparent and does not block user interaction with the underlying view.
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+| Param  | Type | Description |
+| :---: | :---: | :--- |
+| pendoTag | String | A unique identifier for the tagged element. This value is reported in the `pendoTag` field of click analytics payloads and can be targeted from the Pendo web designer. Should be descriptive and unique within the screen context. |
+
+<br>
+
+<b>Class</b>: View
+<br><b>Kind</b>: extension class method
+<br><b>Returns</b>: some View
+<br>
+
+<b>Example</b>:
+
+```swift
+Button("Submit Order") {
+    // Handle submission
+}
+.pendoTag("checkout-submit-button")
+
+VStack {
+    Text("Featured")
+    Image("hero")
+}
+.onTapGesture { openFeatured() }
+.pendoTag("home-featured-card")
+
+Menu("Options") {
+    Button("Share") { share() }
+    Button("Delete", role: .destructive) { delete() }
+}
+.pendoTag("course-card-options")
+```
+
+Resulting analytics payload:
+
+```json
+{
+  "pendoTag": "checkout-submit-button",
+  "clickable": true
+}
 ```
 </details>
 

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -311,10 +311,10 @@ This ensures that Pendo can record click analytics for the element.
 
 4. **Container Views**: <br>
 Container views with `TapGestures` modifiers don't always generate underlying accessibility elements and may cause Pendo SDK to fail tagging them as clickable elements and collecting analytics. This is because such views are purely declarative and serve as instructions for their child elements.<br> 
-Examples of these views include `VStack`, `HStack`, `ZStack`, `LazyHStack`, `LazyVStack`, `LazyVGrid`, `GeometryReader`, and `LazyHGrid`. In that case we recommend using the `pendoRecognizeClickAnalytics()` API on the specific element to ensure interactions are properly recorded. 
+Examples of these views include `VStack`, `HStack`, `ZStack`, `LazyHStack`, `LazyVStack`, `LazyVGrid`, `GeometryReader`, and `LazyHGrid`. In that case we recommend applying the [`.pendoTag("your-tag")`](/api-documentation/native-ios-apis.md#viewpendotag) modifier on the specific element to guarantee a stable, uniquely-identified click event. The legacy [`.pendoRecognizeClickAnalytics()`](/api-documentation/native-ios-apis.md#viewpendorecognizeclickanalytics) modifier is still supported when you only need to make the container discoverable to Pendo's automatic tagging. 
 
-5. **UIContextMenu,Menu,.contextMenu**: <br>
- The UIContextMenu control is not supported in both Swift and SwiftUI. As a result, any interactions with context menus created using this control will not be tracked by the SDK.<br/>
+5. **UIContextMenu, Menu, .contextMenu**: <br>
+ SwiftUI's `Menu` and `.contextMenu` (and the UIKit `UIContextMenuInteraction` they're backed by) are not auto-tagged by the SDK — their items live in a system-owned presentation and are not part of the app view hierarchy. To track these interactions, wrap the trigger view with the [`.pendoTag("your-tag")`](/api-documentation/native-ios-apis.md#viewpendotag) modifier; clicks on the menu trigger will then be reported under the supplied tag.<br/>
 
 ## Developer documentation
 
@@ -339,6 +339,13 @@ _Why aren't some elements being tagged correctly in SwiftUI?_
 * **Tagging elements inside Overlays**: The Pendo SDK automatically detects and tags elements within most SwiftUI `Overlays`. However, if you find that elements inside an overlay are not taggable, it may be because the overlay is not part of the top-most view controller's hierarchy. In these rare cases, you can enable the `pendoOptions.scanFromRootViewController` flag. This allows the SDK to scan from the root view controller, making overlay content accessible. Be aware that this performs a deeper scan of the view hierarchy and may impact performance, so use it only when necessary.
 
 **Using Our API** : <br>
+- [`pendoTag("your-tag")`](/api-documentation/native-ios-apis.md#viewpendotag) - Attaches a unique, stable identifier to a View so Pendo reports clicks on it under the supplied tag. Example:
+  ```swift
+  Button("Submit") { submit() }
+      .pendoTag("checkout-submit-button")
+  ```
+<br>
+
 - `pendoRecognizeClickAnalytics()` - A Pendo-specific modifier to help recognize clickable views that are not automatically tagged. It applies Apple's native accessibility APIs under the hood to combine child elements and mark them as buttons. If you prefer not to use a Pendo API, or for better code clarity, you can apply these native modifiers yourself:
   ```swift
   .accessibilityElement(children: .combine)


### PR DESCRIPTION
## Summary

Adds developer-facing documentation for the new SwiftUI `.pendoTag(_:)` modifier delivered in [APP-149918](https://pendo-io.atlassian.net/browse/APP-149918) / [Insert-iOS-SDK#2385](https://github.com/pendo-io/Insert-iOS-SDK/pull/2385).

- `api-documentation/native-ios-apis.md`: added full `View.pendoTag` reference (signature, availability, behavior, param table, SwiftUI examples incl. Button / tap-gesture container / Menu) and linked it from the `View` index.
- `ios/pnddocs/native-ios.md`:
  - Limitation #4 *Container Views*: recommend `.pendoTag(...)` as the primary API; `.pendoRecognizeClickAnalytics()` retained as legacy fallback.
  - Limitation #5 *UIContextMenu, Menu, .contextMenu*: rewritten — wrapping the trigger with `.pendoTag(...)` now tracks these interactions.
  - SwiftUI Troubleshooting → *Using Our API*: added `pendoTag("your-tag")` bullet with a one-line example.

## Jira

[APP-151465](https://pendo-io.atlassian.net/browse/APP-151465)

Made with [Cursor](https://cursor.com)

[APP-149918]: https://pendo-io.atlassian.net/browse/APP-149918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-151465]: https://pendo-io.atlassian.net/browse/APP-151465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/317)
<!-- Reviewable:end -->
