### PR TITLE
APP-151811 Extend Claude Code sandbox to /tmp/issue-responder

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -107,6 +107,7 @@ jobs:
             --model claude-opus-4-7
             --max-turns 15
             --mcp-config /tmp/issue-responder/mcp-config.json
+            --add-dir /tmp/issue-responder
             --allowedTools "Read,Write(/tmp/issue-responder/**),Bash(echo:*),mcp__github__search_code,mcp__github__get_file_contents,mcp__github__list_issues,mcp__github__get_issue,mcp__github__search_issues,mcp__atlassian__jira_create_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue"
             --disallowedTools "Bash(gh:*),Bash(curl:*),Bash(git:*),Bash(rm:*),WebFetch,WebSearch"
 


### PR DESCRIPTION
## Summary
Fixes the failing `Issue Responder (Auto-triage)` workflow (e.g. [run 24826063147](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/24826063147/job/72662217164)).

The inner Claude Code triage agent could not write `/tmp/issue-responder/verdict.json`:
- **Write tool**: rejected with `Claude requested permissions to write to /tmp/issue-responder/verdict.json, but you haven't granted it yet.` — non-interactive CI has no prompter.
- **Bash output redirection**: rejected with `Output redirection … was blocked. … allowed working directories for this session: '/home/runner/work/pendo-mobile-sdk/pendo-mobile-sdk'.`

`--allowedTools "Write(/tmp/issue-responder/**)"` only pre-approves the tool *pattern*; it does not extend Claude Code's working-directory sandbox. Adding `--add-dir /tmp/issue-responder` to `claude_args` extends the sandbox to cover that directory, which is what both the Write tool and the Bash redirection check enforce.

The agent had been burning all 15 turns retrying Write/printf/heredoc variants, then hitting `max_turns` and exiting non-zero. With this fix, the first Write attempt succeeds and the job completes.

## Refs
- JIRA: APP-151811
- Follow-up to #318 (which added `show_full_output: "true"` and loosened the Write pattern to `**` — both correct, but the sandbox was still the gating check).

## Test plan
- [ ] After merge, manually trigger `Issue Responder (Auto-triage)` via `workflow_dispatch` with `issue_number: 313` (same input as the failed run).
- [ ] Confirm the `Run Claude Code auto-triage` step succeeds.
- [ ] Confirm the transcript shows a single successful `Write` of `/tmp/issue-responder/verdict.json` — no "haven't granted" or "Output redirection blocked" errors.
- [ ] Confirm `Post public comment from verdict` emits `DRY_RUN=1 — would post the following comment:` and prints the body (no real comment posted).
- [ ] Scan the transcript: no Write/Bash outside `/tmp/issue-responder/` (blast radius unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/319)
<!-- Reviewable:end -->
