### PR TITLE
APP-151811 Auto-approve Write in issue-responder sandbox

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -108,6 +108,7 @@ jobs:
             --max-turns 15
             --mcp-config /tmp/issue-responder/mcp-config.json
             --add-dir /tmp/issue-responder
+            --permission-mode acceptEdits
             --allowedTools "Read,Write(/tmp/issue-responder/**),Bash(echo:*),mcp__github__search_code,mcp__github__get_file_contents,mcp__github__list_issues,mcp__github__get_issue,mcp__github__search_issues,mcp__atlassian__jira_create_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue"
             --disallowedTools "Bash(gh:*),Bash(curl:*),Bash(git:*),Bash(rm:*),WebFetch,WebSearch"
 


### PR DESCRIPTION
## Summary
Follow-up to #319. Run [25099255664](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25099255664) confirmed `--add-dir /tmp/issue-responder` fixed the **Bash output redirection** sandbox check, but the **Write tool** is still blocked:

> `Claude requested permissions to write to /tmp/issue-responder/verdict.json, but you haven't granted it yet.`

`--allowedTools "Write(/tmp/issue-responder/**)"` doesn't match — the `**` glob isn't recognized in `Write(...)` scope, so calls fall through to the interactive permission-prompt path and get rejected in non-interactive CI.

`--permission-mode acceptEdits` auto-approves Edit/Write calls without prompting, regardless of allowlist match. Other guardrails unchanged: `--add-dir` keeps the sandbox tight, `--disallowedTools` still blocks `gh`/`curl`/`git`/`rm`/`WebFetch`/`WebSearch`, Bash still limited to `echo:*`.

## Refs
- JIRA: APP-151811
- Follows #319 (which added `--add-dir`).
- Result on master after #319: workflow runs to "success" but no comment posted because `verdict.json` is never written (fail-closed).

## Test plan
- [ ] After merge, trigger `Issue Responder (Auto-triage)` via `workflow_dispatch` with `issue_number: 313` (or any reasonable issue) from `master`.
- [ ] Confirm transcript shows a single successful `Write` of `/tmp/issue-responder/verdict.json` — no "haven't granted" errors.
- [ ] Confirm `Post public comment from verdict` step prints `DRY_RUN=1 — would post the following comment:` (still gated by `vars.ISSUE_RESPONDER_DRY_RUN`).
- [ ] Verify no Write/Bash outside `/tmp/issue-responder/` in the transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/325)
<!-- Reviewable:end -->
