### PR TITLE
APP-150396 Document Room 2.6 minimum version requirement

### DIFF
--- a/android/pnddocs/native-android.md
+++ b/android/pnddocs/native-android.md
@@ -26,6 +26,9 @@
 >
 > If using Jetpack Compose:
 > - androidx.compose.ui:ui `1.5.0` or higher
+>
+> If using Room (Pendo SDK 3.13.0+):
+> - androidx.room `2.6.0` or higher
 
 ## Step 1. Install Pendo SDK
 


### PR DESCRIPTION
## Summary

Pendo Android SDK 3.13 introduces Room 2.6 internally for SR offline support. Hosting apps that also depend on Room must align to 2.6.0 or higher to avoid version conflicts.

Adds a conditional Room requirement to `android/pnddocs/native-android.md`, mirroring the existing `If using Jetpack Compose:` pattern. Wrapper integration docs (RN, RNN, Expo, Flutter, Xamarin) intentionally untouched — those docs do not enumerate transitive Android deps (only the Compose entry in native does).

```diff
 > If using Jetpack Compose:
 > - androidx.compose.ui:ui `1.5.0` or higher
+>
+> If using Room (Pendo SDK 3.13.0+):
+> - androidx.room `2.6.0` or higher
```

## Refs

- JIRA: [APP-150396](https://pendo-io.atlassian.net/browse/APP-150396)
- Internal Confluence "Android 3rd Party Libraries" page is being updated separately to add Room to the dependency inventory.

## Test plan

- [ ] Render `android/pnddocs/native-android.md` on GitHub and confirm the new `If using Room` block sits directly under the Compose conditional, inside the same `[!IMPORTANT] Requirements` admonition.
- [ ] Confirm no other docs were modified (`git diff master --stat` shows only `native-android.md`).

[APP-150396]: https://pendo-io.atlassian.net/browse/APP-150396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/326)
<!-- Reviewable:end -->
