### PR TITLE
APP-154458 Document Swift Package Manager support in Flutter iOS install instructions

### DIFF
--- a/ios/pnddocs/flutter-ios.md
+++ b/ios/pnddocs/flutter-ios.md
@@ -10,6 +10,7 @@
 >Requirements:
 >- Flutter: ">=3.16.0"
 >- SDK: ">=3.2.0 < 4.0.0"
+>- iOS dependency manager: CocoaPods (default) or Swift Package Manager (requires Flutter 3.24 or later)
 >
 >Supported Navigation Libraries:
 >
@@ -18,6 +19,60 @@
 
 ## Step 1. Add Pendo dependency 
 In the root folder of your flutter app add the Pendo package: `flutter pub add pendo_sdk`.
+
+### iOS dependency manager
+
+The Pendo Flutter plugin supports both **CocoaPods** and **Swift Package Manager (SPM)** for iOS. Flutter automatically uses whichever your host app is configured for — the plugin is fully compatible with either, and you do not need to change anything in the plugin itself.
+
+<details open>
+<summary><b>CocoaPods (default)</b></summary>
+
+No additional steps. Flutter runs `pod install` automatically the first time you build for iOS, and the Pendo native SDK is pulled from CocoaPods.
+
+If you want to install pods manually before your first build:
+
+```sh
+cd ios
+pod install
+```
+</details>
+
+<details>
+<summary><b>Swift Package Manager</b></summary>
+
+> [!IMPORTANT]
+> Swift Package Manager support in the Pendo Flutter plugin requires **Flutter 3.24 or later** on the host application.
+
+**1. Enable SPM** (one-time, per machine):
+
+```sh
+flutter config --enable-swift-package-manager
+```
+
+**2. Build the app:**
+
+```sh
+flutter build ios
+```
+
+Flutter generates the SPM scaffolding automatically under `ios/Flutter/ephemeral/Packages/` and resolves the plugin and its native Pendo dependency from the [Pendo iOS Swift Package](https://github.com/pendo-io/pendo-mobile-sdk). The native Pendo `XCFramework` is downloaded from Pendo's artifactory on first resolution. No `Podfile` is needed.
+
+**3. Migrating an existing project from CocoaPods to SPM:**
+
+If your iOS project previously used CocoaPods, remove the CocoaPods artifacts before the first SPM build:
+
+```sh
+cd ios
+rm -rf Podfile Podfile.lock Pods
+cd ..
+flutter clean
+flutter build ios
+```
+
+> [!TIP]
+> To verify SPM is in use after building, look for `ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/` — this is Flutter's generated SPM project. If you see `ios/Pods/` and no `Packages/` directory, the build is still using CocoaPods.
+
+</details>
 
 ## Step 2. Integrate with the Pendo SDK
 


### PR DESCRIPTION
## Summary

Adds a CocoaPods vs Swift Package Manager section to `ios/pnddocs/flutter-ios.md` so customers know:

- Both dependency managers are supported by the Pendo Flutter plugin.
- SPM requires Flutter 3.24 or later on the host application.
- How to enable SPM (`flutter config --enable-swift-package-manager`).
- What to expect on first build (Flutter generates SPM scaffolding under `ios/Flutter/ephemeral/Packages/`; the native Pendo XCFramework is downloaded automatically).
- How to verify which manager is in use.
- How to migrate an existing CocoaPods-based project to SPM.

Pairs with [APP-154453](https://pendo-io.atlassian.net/browse/APP-154453) (Flutter plugin SPM implementation; PR pendo-io/flutterPlugin#505) under epic [APP-147001](https://pendo-io.atlassian.net/browse/APP-147001) (CocoaPods deprecation).

## Out of scope

`other/native-with-flutter-components.md` (the add-to-app scenario where Flutter is embedded into a native iOS app) was deliberately left unchanged. Flutter add-to-app + SPM is a manual workflow that Pendo hasn't validated end-to-end. Tracked separately as [APP-154461](https://pendo-io.atlassian.net/browse/APP-154461).

## Test plan

- [ ] Reviewer: confirm the rendered markdown looks correct on GitHub (collapsible `<details>` blocks for the CocoaPods vs SPM split).
- [ ] Reviewer: sanity-check the SPM commands against a fresh Flutter project — `flutter config --enable-swift-package-manager` then `flutter create test_app && flutter pub add pendo_sdk && cd test_app && flutter build ios`.
- [ ] Reviewer: confirm the Flutter 3.24 version floor we mention matches what the plugin actually supports for SPM (PR #505 was validated on Flutter 3.41.6; 3.24 was the first stable Flutter SPM release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-154453]: https://pendo-io.atlassian.net/browse/APP-154453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-147001]: https://pendo-io.atlassian.net/browse/APP-147001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-154461]: https://pendo-io.atlassian.net/browse/APP-154461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/329)
<!-- Reviewable:end -->
