### PR TITLE
APP-154463 Allow non-write users in issue-responder auto-triage

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -97,6 +97,18 @@ jobs:
         uses: anthropics/claude-code-action@8a953dedac4f533f912f13656070914693ed0575  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Required for allowed_non_write_users to take effect (the action only
+          # honors the bypass when github_token is passed explicitly, not when
+          # it falls back to GitHub-App auto-token mode).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Skip the action's built-in "actor must have write access" check.
+          # External customers opening issues have no repo permission, so without
+          # this the auto-triage fails at App token exchange on every real issue.
+          # Safety is preserved by the existing guardrails: minimal job
+          # permissions, --allowedTools / --disallowedTools whitelist, sandboxed
+          # Write path (/tmp/issue-responder/**), and the downstream comment step
+          # only ever posts one of two canned strings based on verdict.json.
+          allowed_non_write_users: "*"
           show_full_output: "true"
           prompt: |
             Read `.github/issue-responder/prompt.md` for the full role, flow, safety rules, and output schema.


### PR DESCRIPTION
## Summary
Fixes the `Issue Responder (Auto-triage)` workflow for its primary use case: external customer-filed issues.

`anthropics/claude-code-action@v1` performs a hardcoded actor-permission check via GitHub App token exchange and refuses to run for users without `write` permission on the repo. Every real customer report comes from an external user (`author_association: NONE`), so the action rejects them at `App token exchange failed: 401 Unauthorized - User does not have write access on this repository`. Manual `workflow_dispatch` runs always succeed because the triggering actor is a collaborator — which is why this looked like "only works manually."

Evidence:
- [Run 25809963211](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25809963211) on issue #327 (MEMBER author) — SUCCESS, log line `Actor has write access: write`.
- [Run 25940465861](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25940465861) on issue #328 (external author `rsegtx`) — FAILED at the Claude step with `Action failed with error: User does not have write access on this repository`.

The action exposes `allowed_non_write_users` precisely for headless auto-triage. The bypass is gated on passing an explicit `github_token` input (it is not honored under GitHub-App auto-token mode), so we pass both.

## Why this is safe
The existing workflow already implements the guardrails the action's own security doc requires for using this bypass:
- Minimal job `permissions:` (`contents: read`, `issues: write`, `id-token: write`).
- `--allowedTools` whitelisted to read-only MCP + `Write(/tmp/issue-responder/**)` + `Bash(echo:*)`.
- `--disallowedTools` blocks `gh`, `git`, `curl`, `rm`, `WebFetch`, `WebSearch`.
- `prompt.md` instructs Claude that title/body are untrusted and that its only output is `/tmp/issue-responder/verdict.json`.
- The downstream `Post public comment from verdict` step posts one of two canned strings chosen by `case "$verdict" in …` — Claude cannot influence the public comment text.

The bypass does NOT grant external users any GitHub-level permission. They still cannot use `workflow_dispatch` (GitHub itself gates that on `actions: write`); they can only cause the workflow to run by opening an issue, which is the intended behavior.

## Refs
- JIRA: APP-154463
- Workflow: `.github/workflows/issue-responder.yml`
- Failing run that motivated the fix: [25940465861](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25940465861) (issue #328)

## Test plan
- [ ] After merge to master, `gh run rerun 25940465861` and confirm the `Run Claude Code auto-triage` step now reaches Claude instead of dying at App token exchange.
- [ ] Confirm `/tmp/issue-responder/verdict.json` is produced and the `Post public comment from verdict` step posts one of the two canned strings on issue #328 (DRY_RUN is `0` via repo variable).
- [ ] Wait for the next real external issue and confirm it auto-triages end to end.
- [ ] Sanity: re-run `workflow_dispatch` with `issue_number: 313` — should still succeed (collaborator path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/330)
<!-- Reviewable:end -->
