### PR TITLE
APP-154463 Opt out of claude-code-action subprocess sandbox

### DIFF
--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -24,6 +24,23 @@ jobs:
       id-token: write
     env:
       DRY_RUN: ${{ vars.ISSUE_RESPONDER_DRY_RUN || '1' }}
+      # Opt out of claude-code-action's subprocess sandbox (bubblewrap +
+      # PID namespace + env scrub). The sandbox activates whenever
+      # allowed_non_write_users is set and breaks two things in this workflow:
+      #   1. The Atlassian MCP docker container does not receive its JIRA_*
+      #      env vars (env-scrub strips them), so the MCP fails to connect
+      #      and Claude reports "Atlassian MCP tools aren't available".
+      #   2. /tmp/issue-responder is remapped by bubblewrap so the
+      #      --permission-mode acceptEdits + --add-dir /tmp/issue-responder
+      #      + --allowedTools "Write(/tmp/issue-responder/**)" combo no
+      #      longer auto-approves the verdict.json write — every Write call
+      #      returns "Claude requested permissions ... but you haven't
+      #      granted it yet", verdict.json is never produced, and the
+      #      downstream comment step fails-closed with no public comment.
+      # Defense-in-depth is preserved by the existing --disallowedTools
+      # (Bash(gh|curl|git|rm:*), WebFetch, WebSearch) and the canned
+      # comment text in the downstream step.
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "0"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6


### PR DESCRIPTION
## Summary
Follow-up to #330. That PR correctly unblocked the actor write-access check (confirmed in [run 25993867494](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25993867494) by log line `Bypassing write permission check for lorinsherry1 due to allowed_non_write_users='*'`), but exposed a deeper failure mode: when `allowed_non_write_users` is set, `claude-code-action` activates a *heightened* subprocess sandbox (bubblewrap PID-namespace + env scrub), and that sandbox breaks both of the things this workflow depends on:

1. **Atlassian MCP cannot connect.** The env-scrub strips `JIRA_URL` / `JIRA_USERNAME` / `JIRA_API_TOKEN` before they reach the `ghcr.io/sooperset/mcp-atlassian` container. Claude logged: `"Atlassian MCP tools aren't available in this environment, so I can't perform the JIRA idempotency check or create a ticket."`

2. **Write tool is denied for `/tmp/issue-responder/verdict.json`.** The bubblewrap PID-namespace remaps `/tmp`, so the existing `--permission-mode acceptEdits` + `--add-dir /tmp/issue-responder` + `--allowedTools \"Write(/tmp/issue-responder/**)\"` combo no longer auto-approves. Every Write call returns:
   > `Error: Claude requested permissions to write to /tmp/issue-responder/verdict.json, but you haven't granted it yet.`
   
   So `verdict.json` is never produced and the `Post public comment from verdict` step fails-closed with `verdict.json not produced; skipping public comment (fail-closed)`.

The fix is the action's own documented opt-out: set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0`. The action's install script honors it explicitly:
```bash
if [ \"${CLAUDE_CODE_SUBPROCESS_ENV_SCRUB:-}\" = \"0\" ]; then
  echo \"Subprocess isolation opted out via CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0\"
  exit 0
fi
```

## Why this is safe
The env-scrub defense is a guard against prompt-injection exfiltrating secrets via subprocess calls. We already prevent that at the tool-allowlist layer:
- `--disallowedTools` blocks `Bash(gh:*)`, `Bash(curl:*)`, `Bash(git:*)`, `Bash(rm:*)`, `WebFetch`, `WebSearch` — every channel Claude could use to send data off the runner.
- `--allowedTools` only permits read-only MCP, sandboxed `Write(/tmp/issue-responder/**)`, and `Bash(echo:*)`.
- The public comment is canned text chosen by `case \"$verdict\" in …` in the downstream bash step — Claude cannot influence the visible comment.

So opting out of env-scrub does not give an attacker any new exfiltration channel.

## Refs
- JIRA: APP-154463
- Failing run that motivated this follow-up: [25993867494](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25993867494) (issue #331, external user `lorinsherry1`)
- Prior PR: #330

## Test plan
- [ ] After merge, `gh run rerun 25993867494` and confirm:
  - log no longer shows `Selecting previously unselected package bubblewrap`
  - Atlassian MCP connects (look for `\"name\": \"atlassian\", \"status\": \"connected\"`)
  - Claude successfully writes `/tmp/issue-responder/verdict.json` (no `Error: Claude requested permissions ...`)
  - The `Post public comment from verdict` step posts one of the two canned strings on issue #331
- [ ] Confirm the comment now appears at https://github.com/pendo-io/pendo-mobile-sdk/issues/331
- [ ] Sanity-check: open a fresh test issue from an external account and confirm the bot comments end-to-end without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/332)
<!-- Reviewable:end -->
