### PR TITLE
APP-154463 Daily Slack digest + manual batch triage of pending issues

### DIFF
--- a/.github/issue-responder/prompt.md
+++ b/.github/issue-responder/prompt.md
@@ -11,14 +11,15 @@ You are an automated triage agent for the **public** GitHub repository `pendo-io
 
 ## Critical safety rules
 
-This workflow is triggered by a **public** repository. Anything written to the GitHub issue is visible to the world.
+This workflow runs in a **public** GitHub repository. Anything written to the GitHub issue is visible to the world, **and the GitHub Actions logs themselves are also publicly visible**. Treat anything that reaches stdout as world-readable.
 
 - **You must not write to the GitHub issue.** Do not post comments, do not edit the title/body, do not label or close it. Tooling that could do this is blocked; treat it as an invariant anyway.
-- **You must not call `gh`, `git`, `curl`, fetch URLs, or run arbitrary shell.** These are disallowed.
-- **Internal details (file paths, function names, snippets, reasoning) belong only inside the JIRA ticket description and the `verdict.json` you produce.** They are internal.
+- **You must not call `gh`, `git`, `curl`, fetch URLs, or run any shell command.** All `Bash`, `WebFetch`, and `WebSearch` tools are disallowed.
+- **You must not write internal details to stdout.** The Actions log is public. Internal details (file paths, function names, snippets, hypotheses, reasoning) belong only inside the JIRA ticket description (internal), `verdict.json` (consumed by the next workflow step; not echoed), or `dry-run-payload.json` (ephemeral, on the runner).
 - **Your only outputs:**
-  1. At most one JIRA ticket (via Atlassian MCP), unless one already exists for this GitHub issue URL — in which case reuse it.
+  1. At most one JIRA ticket (via Atlassian MCP), unless one already exists for this GitHub issue URL — in which case reuse it. Skipped when `dry_run` is `true`.
   2. Exactly one file at `/tmp/issue-responder/verdict.json` matching the schema below.
+  3. When `dry_run` is `true`: additionally a file at `/tmp/issue-responder/dry-run-payload.json` with the intended JIRA payload.
 
 ## Inputs
 
@@ -71,7 +72,7 @@ Infer which platform(s) are relevant from the issue title, body, and labels. Onl
      - `Matched files:` bullet list of `<repo>: <path>` with 1-line snippet each.
      - `Suggested next steps: …`
    - Labels: `auto-triaged` and `platform-<ios|android|react-native|flutter|maui|cmp|automation>` for each inferred platform.
-   - If `dry_run` is `true`: **do not call** `mcp__atlassian__jira_create_issue`. Instead, echo the intended payload to stdout via `Bash(echo:*)` and use placeholders `jira_key="DRYRUN-0"` and `jira_url=""` in `verdict.json`.
+   - If `dry_run` is `true`: **do not call** `mcp__atlassian__jira_create_issue`. Instead, `Write` the intended payload to `/tmp/issue-responder/dry-run-payload.json` (a maintainer can inspect that file by adding a temporary debug step). Use placeholders `jira_key="DRYRUN-0"` and `jira_url=""` in `verdict.json`. **Do not** echo internal details to stdout — this workflow runs in a public repository and stdout is captured in publicly-visible Actions logs.
 
 7. **Write `/tmp/issue-responder/verdict.json`** using the `Write` tool:
    ```json

--- a/.github/workflows/daily-issue-digest.yml
+++ b/.github/workflows/daily-issue-digest.yml
@@ -1,0 +1,134 @@
+name: Daily Issue Digest (Slack)
+
+# Daily summary of open mobile-sdk issues posted to #team-apex with one
+# "🤖 Triage pending issues" button. The button opens the issue-responder
+# workflow's Actions UI where a Pendo team member clicks "Run workflow" to
+# kick off the AI batch triage manually. The AI never runs unattended.
+#
+# Required secret on this repo: SLACK_TEAM_APEX_WEBHOOK_URL — a Slack
+# Incoming Webhook URL bound to the #team-apex channel.
+on:
+  schedule:
+    # 07:00 UTC daily.
+    # = 10:00 IDT (Israel summer, Apr–late Oct) → matches the target.
+    # = 09:00 IST (Israel winter, late Oct–Mar) → user accepted this drift
+    #   over either a two-cron split (imprecise at the DST switchover days)
+    #   or a fixed UTC time that misses 10:00 IL year-round.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: daily-issue-digest
+  cancel-in-progress: false
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - name: Fetch open issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh issue list --repo "$REPO" --state open --limit 50 \
+            --json number,url,title,author,createdAt,labels,comments \
+            > issues.json
+
+      - name: Build Slack Block Kit payload
+        env:
+          WORKFLOW_URL: "https://github.com/${{ github.repository }}/actions/workflows/issue-responder.yml"
+        run: |
+          set -euo pipefail
+          MARKER='<!-- pendo-issue-responder -->'
+
+          jq -n \
+            --slurpfile issues issues.json \
+            --arg workflow_url "$WORKFLOW_URL" \
+            --arg marker "$MARKER" '
+            ($issues[0]) as $all
+            | ($all | length) as $total
+            | ($all
+                | map(select(([.comments[].body | startswith($marker)] | any) | not))
+              ) as $pending
+            | ($pending | length) as $pending_count
+            | ($total - $pending_count) as $triaged_count
+            | (if $pending_count > 0
+                then "🤖 Triage \($pending_count) pending issue\(if $pending_count == 1 then "" else "s" end)"
+                else "🤖 Re-run triage (all already answered)"
+              end) as $btn_text
+            | (if $total > 0
+                then ($all | map(
+                    (([.comments[].body | startswith($marker)] | any)) as $triaged
+                    | (.title | if length > 120 then .[:117] + "…" else . end) as $short_title
+                    | (if (.labels | length) > 0
+                        then (.labels | map(.name) | join(", "))
+                        else "_none_"
+                       end) as $label_str
+                    | {
+                        type: "section",
+                        text: {
+                          type: "mrkdwn",
+                          text: ("\(if $triaged then "✅" else "⏳" end) *<\(.url)|#\(.number)>* — \($short_title)\n_by `\(.author.login)` · opened \(.createdAt | sub("T.*"; "")) · labels: \($label_str)_")
+                        }
+                      }
+                  ))
+                else [
+                  { type: "section", text: { type: "mrkdwn", text: "_No open issues. Nothing to do today._" } }
+                ]
+              end) as $issue_blocks
+            | {
+                text: "📋 Mobile SDK — \($total) open · \($pending_count) pending",
+                blocks: (
+                  [
+                    { type: "header", text: { type: "plain_text", text: "📋 Mobile SDK Issues — \($total) open" } },
+                    {
+                      type: "context",
+                      elements: [{
+                        type: "mrkdwn",
+                        text: "✅ \($triaged_count) already triaged · ⏳ \($pending_count) pending · click the button to run AI triage on the pending ones (idempotent)."
+                      }]
+                    },
+                    { type: "divider" }
+                  ]
+                  + $issue_blocks
+                  + [
+                      { type: "divider" },
+                      {
+                        type: "actions",
+                        elements: [{
+                          type: "button",
+                          text: { type: "plain_text", text: $btn_text },
+                          style: "primary",
+                          url: $workflow_url
+                        }]
+                      },
+                      {
+                        type: "context",
+                        elements: [{
+                          type: "mrkdwn",
+                          text: "Button opens the workflow page on GitHub — click *Run workflow* there to start the AI triage. Already-answered issues are skipped automatically."
+                        }]
+                      }
+                  ]
+                )
+              }' > slack-payload.json
+
+      - name: Post to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TEAM_APEX_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          : "${SLACK_WEBHOOK_URL:?missing secret SLACK_TEAM_APEX_WEBHOOK_URL (Slack Incoming Webhook bound to #team-apex)}"
+
+          # Slack incoming webhooks return "ok" (200) on success, a non-2xx
+          # with body on failure. -f makes curl fail the step on non-2xx.
+          curl -sSf -X POST -H 'Content-type: application/json' \
+            --data @slack-payload.json \
+            "$SLACK_WEBHOOK_URL"
+          echo
+          echo "Slack digest posted."

--- a/.github/workflows/issue-responder.yml
+++ b/.github/workflows/issue-responder.yml
@@ -1,21 +1,61 @@
 name: Issue Responder (Auto-triage)
 
+# SECURITY: workflow_dispatch only. The previous `issues: opened` trigger let
+# the workflow fire on actor-controllable events (external customers filing
+# bugs), which required allowed_non_write_users on claude-code-action and
+# created a meaningful prompt-injection surface against the GH_PAT_SDK_READ
+# private-repo access. Now triggered manually by a Pendo team member (via the
+# "🤖 Triage pending issues" button in the #team-apex daily digest), so the
+# AI step's actor is always a collaborator with write access. No
+# allowed_non_write_users needed; no heightened bubblewrap sandbox.
 on:
-  issues:
-    types: [opened]
   workflow_dispatch:
-    inputs:
-      issue_number:
-        description: "Issue number to triage (manual dry-run testing)"
-        required: true
-        type: string
 
 concurrency:
-  group: issue-responder-${{ github.event.issue.number || inputs.issue_number }}
+  group: issue-responder
   cancel-in-progress: false
 
 jobs:
+  # First job: cheap query to figure out which open issues still need a bot
+  # comment. Outputs the list as JSON so the second job can fan out with a
+  # matrix — one matrix job per pending issue.
+  find-pending:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+    outputs:
+      count: ${{ steps.list.outputs.count }}
+      issues: ${{ steps.list.outputs.issues }}
+    steps:
+      - name: List open issues without bot comment
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh issue list --repo "$REPO" --state open --limit 50 \
+            --json number,title,comments > /tmp/all-open.json
+
+          # Idempotency: skip any issue that already has a comment starting
+          # with the well-known marker. This is what makes "run it tomorrow
+          # too" safe — already-answered issues are passed over.
+          numbers=$(jq -c '[.[]
+                | select(([.comments[].body | startswith("<!-- pendo-issue-responder -->")] | any) | not)
+                | .number]' /tmp/all-open.json)
+
+          count=$(jq 'length' <<< "$numbers")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "issues=$numbers" >> "$GITHUB_OUTPUT"
+          echo "Pending issues (count=$count): $numbers"
+
+  # Second job: one matrix instance per pending issue. Skipped entirely if
+  # find-pending returned zero.
   triage:
+    needs: find-pending
+    if: needs.find-pending.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -24,6 +64,16 @@ jobs:
       id-token: write
     env:
       DRY_RUN: ${{ vars.ISSUE_RESPONDER_DRY_RUN || '1' }}
+      ISSUE_NUMBER: ${{ matrix.issue_number }}
+    strategy:
+      # Serialize to be polite to the Anthropic / GitHub / Jira APIs and to
+      # avoid two matrix jobs racing on the Jira JQL idempotency check for
+      # the same URL (can't happen with distinct issue numbers, but cheap
+      # safety).
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        issue_number: ${{ fromJSON(needs.find-pending.outputs.issues) }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
@@ -58,33 +108,23 @@ jobs:
             .github/issue-responder/mcp-config.template.json \
             > /tmp/issue-responder/mcp-config.json
 
-      - name: Resolve issue number
-        id: issue
+      - name: Validate issue number
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          NUMBER: ${{ matrix.issue_number }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "issues" ]; then
-            number="$EVENT_ISSUE_NUMBER"
-          else
-            number="$INPUT_ISSUE_NUMBER"
-          fi
-          # Strict digit-only validation: defends against injection via $GITHUB_OUTPUT
-          # (newlines or `=` in the value could otherwise forge additional outputs).
-          if ! printf '%s' "$number" | grep -qE '^[0-9]+$'; then
-            echo "::error::issue number must match ^[0-9]+$; got: $(printf '%q' "$number")"
+          # Defends against unexpected matrix expansion content (matrix value
+          # is interpolated into shell context below).
+          if ! printf '%s' "$NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::error::matrix.issue_number must match ^[0-9]+$; got: $(printf '%q' "$NUMBER")"
             exit 1
           fi
-          echo "number=$number" >> "$GITHUB_OUTPUT"
-          echo "Resolved issue #$number"
+          echo "Triaging issue #$NUMBER"
 
       - name: Write issue context
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         run: |
           set -euo pipefail
           gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json url,number,title,body,labels \
@@ -92,24 +132,21 @@ jobs:
                 '{url, number, title, body, labels: [.labels[].name], dry_run: $dry_run}' \
             > /tmp/issue-responder/issue.json
 
+      # SECURITY: this runs in a PUBLIC repo, so Actions logs are world-
+      # readable. The hardening below closes the two channels through which
+      # private SDK code could leak into those logs:
+      #   * No show_full_output → the action does not dump Claude's tool-call
+      #     transcript (which would include mcp__github__search_code results)
+      #     to stdout.
+      #   * No Bash(echo:*) in --allowedTools and --disallowedTools widened
+      #     to "Bash,WebFetch,WebSearch" → Claude has zero shell available,
+      #     so even under prompt injection it cannot echo private content to
+      #     stdout. prompt.md routes dry-run output to a Write instead.
       - name: Run Claude Code auto-triage
         id: claude
         uses: anthropics/claude-code-action@8a953dedac4f533f912f13656070914693ed0575  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Required for allowed_non_write_users to take effect (the action only
-          # honors the bypass when github_token is passed explicitly, not when
-          # it falls back to GitHub-App auto-token mode).
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Skip the action's built-in "actor must have write access" check.
-          # External customers opening issues have no repo permission, so without
-          # this the auto-triage fails at App token exchange on every real issue.
-          # Safety is preserved by the existing guardrails: minimal job
-          # permissions, --allowedTools / --disallowedTools whitelist, sandboxed
-          # Write path (/tmp/issue-responder/**), and the downstream comment step
-          # only ever posts one of two canned strings based on verdict.json.
-          allowed_non_write_users: "*"
-          show_full_output: "true"
           prompt: |
             Read `.github/issue-responder/prompt.md` for the full role, flow, safety rules, and output schema.
             Read `/tmp/issue-responder/issue.json` for the GitHub issue to triage.
@@ -121,14 +158,13 @@ jobs:
             --mcp-config /tmp/issue-responder/mcp-config.json
             --add-dir /tmp/issue-responder
             --permission-mode acceptEdits
-            --allowedTools "Read,Write(/tmp/issue-responder/**),Bash(echo:*),mcp__github__search_code,mcp__github__get_file_contents,mcp__github__list_issues,mcp__github__get_issue,mcp__github__search_issues,mcp__atlassian__jira_create_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue"
-            --disallowedTools "Bash(gh:*),Bash(curl:*),Bash(git:*),Bash(rm:*),WebFetch,WebSearch"
+            --allowedTools "Read,Write(/tmp/issue-responder/**),mcp__github__search_code,mcp__github__get_file_contents,mcp__github__list_issues,mcp__github__get_issue,mcp__github__search_issues,mcp__atlassian__jira_create_issue,mcp__atlassian__jira_search,mcp__atlassian__jira_get_issue"
+            --disallowedTools "Bash,WebFetch,WebSearch"
 
       - name: Post public comment from verdict
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -154,6 +190,9 @@ jobs:
               ;;
           esac
 
+          # Defense-in-depth: even though find-pending already filtered out
+          # issues with a bot comment, re-check at write time in case a human
+          # or another run posted one between find-pending and now.
           existing=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json comments \
             --jq '[.comments[] | select(.body | startswith("<!-- pendo-issue-responder -->"))] | length')
           if [ "${existing:-0}" != "0" ]; then
@@ -162,7 +201,7 @@ jobs:
           fi
 
           if [ "$DRY_RUN" = "1" ]; then
-            echo "DRY_RUN=1 — would post the following comment:"
+            echo "DRY_RUN=1 — would post the following comment on issue #$ISSUE_NUMBER:"
             echo "----"
             printf '%s\n' "$BODY"
             echo "----"


### PR DESCRIPTION
## Summary
Replaces the auto-triage-on-`issues:opened` architecture with a **daily Slack digest in `#team-apex` + one manual button that batch-triages every still-pending open issue**. The AI step never auto-fires anymore — it runs only when a Pendo team member clicks the button.

## Why this shape (vs. the previous attempts)
- **#330** (merged) set `allowed_non_write_users: "*"` on `claude-code-action` so the workflow would fire for external customer issues. That worked at the actor-check level but activated the action's heightened bubblewrap+env-scrub sandbox, which broke Atlassian MCP loading and Write-to-`verdict.json`. Run [25993867494](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25993867494) confirmed this: the bypass log line `Bypassing write permission check for lorinsherry1 due to allowed_non_write_users='*'` appears, then `Error: Claude requested permissions to write to /tmp/issue-responder/verdict.json, but you haven't granted it yet` and no comment is posted.
- **#333** (closed) tried replacing `claude-code-action` with the Claude CLI directly. A security review then flagged two pre-existing HIGH-severity findings: (a) `--verbose` / `show_full_output: "true"` dumps Claude's tool-call transcript (including `mcp__github__search_code` results from private SDK repos) to the public Actions log on this PUBLIC repo, and (b) `Bash(echo:*)` is a direct exfiltration channel into the same public log. The user closed #333 over residual risk.
- **This PR** removes the entire attacker-controllable trigger surface: only `workflow_dispatch` initiated by a Pendo collaborator can ever invoke the AI step. With that constraint the action's default actor check passes naturally, so we revert #330's bypass and the heightened sandbox is never engaged. The two log-leakage findings are closed in the same diff (dropped `show_full_output`, removed `Bash(echo:*)` from `--allowedTools`, widened `--disallowedTools` to `Bash,WebFetch,WebSearch`, rerouted dry-run output to a Write).

## Architecture

```
07:00 UTC daily                              Pendo team member clicks button
  │                                                    │
  v                                                    v
daily-issue-digest.yml                       issue-responder.yml (workflow_dispatch only)
  • gh issue list                              • Job 1 (find-pending):
  • classify ✅ / ⏳ via marker                   - gh issue list
  • Slack Block Kit message                      - filter out anything carrying
    - per-issue status row                         the `<!-- pendo-issue-responder -->`
    - single "🤖 Triage pending issues"             comment marker
      button                                       - output JSON array of numbers
  • POST to #team-apex via webhook             • Job 2 (triage, matrix per issue):
                                                 - matrix: each pending issue number
                                                 - same AI step as before, minus the
                                                   PR #330 inputs and the leak channels
                                                 - canned-comment poster (unchanged)
```

The button is a Slack Block Kit URL button pointing to `actions/workflows/issue-responder.yml`. The team member clicks it → lands on the workflow's Actions UI → clicks "Run workflow" (no inputs needed) → batch run starts. Two clicks total, no Slack App / Slack Workflow Builder / dispatch-PAT to maintain.

## Idempotency

Pressing the button on consecutive days does not re-comment on already-answered issues:

- `find-pending` filters by the presence of the `<!-- pendo-issue-responder -->` comment marker.
- The downstream `Post public comment from verdict` step re-checks the marker as defense-in-depth before posting.
- `prompt.md` also runs a JQL idempotency check against the APEX project so a duplicate Jira ticket isn't created for the same GitHub URL.

So: open today → answered today; reopen the same issue tomorrow → still answered (comment still there) → skipped. New issue opened today between digests → ⏳ in tomorrow's digest → answered when the button is clicked.

## Security properties

| Risk | Before | After |
|---|---|---|
| External actor triggers AI on attacker-controlled input | Possible (`issues:opened` + `allowed_non_write_users`) | **Impossible** — `workflow_dispatch` is gated on `actions:write` by GitHub, external users have none |
| Heightened bubblewrap sandbox blocks Atlassian MCP / Writes | Active | **Never engages** — actor always has write access |
| Private SDK code in public Actions log via `--verbose` | Yes | **No** — `show_full_output` removed |
| `Bash(echo:*)` exfiltration to public Actions log | Yes | **No** — `Bash` entirely disallowed |
| Prompt-injection by random GitHub user | Yes | **No** — they cannot invoke the workflow at all |
| Prompt-injection by issue *content* once a Pendo employee triggers triage | Yes (residual) | Yes (residual) — bounded by tool allowlist + canned-comment design, same as before |

## One-time setup required before this works

1. In Slack, create an **Incoming Webhook** bound to `#team-apex` (Slack admin → Apps → Incoming Webhooks → Add to Slack → choose `#team-apex` → copy URL).
2. On `pendo-io/pendo-mobile-sdk` → Settings → Secrets and variables → Actions → New repository secret:
   - Name: `SLACK_TEAM_APEX_WEBHOOK_URL`
   - Value: the webhook URL from step 1.

Without this secret the digest workflow will fail loudly with `missing secret SLACK_TEAM_APEX_WEBHOOK_URL`.

## Test plan

- [ ] Add the Slack webhook secret per the setup above.
- [ ] After merge, trigger `Daily Issue Digest (Slack)` manually via `workflow_dispatch`. Confirm a message appears in `#team-apex` with one row per open issue, ✅/⏳ markers, and one primary button at the bottom.
- [ ] Click the button → lands on the `Issue Responder (Auto-triage)` workflow page on GitHub → click "Run workflow".
- [ ] Watch the run:
  - `find-pending` should emit a non-zero `count` for the open issues that don't carry the marker (e.g., #331).
  - One matrix job per pending issue.
  - Each runs Claude, writes `verdict.json`, and posts one of the two canned comments.
- [ ] Re-trigger immediately. `find-pending` should now emit `count=0`; the matrix job is skipped; no comments are posted.
- [ ] Re-trigger the digest workflow. The Slack message should now show every issue as ✅.
- [ ] Verify no historical `issues: opened` runs trigger (the trigger is gone from `on:`).

## Refs
- JIRA: APP-154463
- Failing run that motivated the rethink: [25993867494](https://github.com/pendo-io/pendo-mobile-sdk/actions/runs/25993867494) (issue #331)
- Previous attempts: #330 (merged, actor-bypass), #332 (closed, env-scrub opt-out), #333 (closed, direct CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/334)
<!-- Reviewable:end -->
