### PR TITLE
APP-154941 Release version 3.13.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pendo",
-            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.0.11707/pendo-ios-sdk-xcframework.3.13.0.11707.zip",
-            checksum: "cf5d973e150a04eebbcbf8efd7dca8962e862ed8a45f4b7019e3bfa9ce718a96"
+            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.1.11743/pendo-ios-sdk-xcframework.3.13.1.11743.zip",
+            checksum: "24ed9a7aea9ff04b071c3e479567ddd0452138326e64ea141121e63263afa314"
         ),
     ]
 )


### PR DESCRIPTION
## Summary

Manual SPM release for SDK **3.13.1.11743**. The CircleCI `release-framework` job for pipeline 11743 failed today due to CocoaPods Trunk infrastructure issues (504/500/409 chain — see ticket for full timeline), so `release-swift-package` could not run downstream. CocoaPods Trunk and Artifactory both already have 3.13.1.11743 published; this PR only handles the SPM side.

### Changes

- `Package.swift`:
  - `url` → `ios-sdk-release/3.13.1.11743/pendo-ios-sdk-xcframework.3.13.1.11743.zip`
  - `checksum` → `24ed9a7aea9ff04b071c3e479567ddd0452138326e64ea141121e63263afa314` (computed via `swift package compute-checksum` on the released zip)

### Mirroring CI

This matches exactly what `release-swift-package` does in `.circleci/generated_config.yml:734-753`:

```sh
sed "s/{{ CHECKSUM }}/${ARTIFACT_SWIFT_CHECKSUM}/; s/{{ SOURCE }}/...3.13.1.11743.../" \
  ../swift/Package.swift > ./Package.swift
git commit -m "Release version 3.13.1"
git tag -a 3.13.1 -m "Add release version tag 3.13.1"
git push --atomic origin master 3.13.1
```

The tag `3.13.1` is **not** pushed in this PR — it will be created and pushed after merge, pointing at the resulting master commit (see Test plan below).

### Verification done

- [x] Zip at the new URL returns HTTP 200 (~19.2 MB)
- [x] `swift package compute-checksum` on the downloaded zip returns `24ed9a7a…afa314`
- [x] No existing tag `3.13.1` on this repo
- [x] CocoaPods CDN shard `7_e_c` shows `Pendo 3.13.1.11743` published

## Test plan

After merge:

1. Locally on master: `git pull --ff-only`
2. `git tag -a 3.13.1 -m "Add release version tag 3.13.1" $(git rev-parse origin/master)`
3. `git push origin 3.13.1`
4. Smoke-test in a throwaway Xcode project with SPM dependency `https://github.com/pendo-io/pendo-mobile-sdk` from `3.13.1` — confirm it resolves, downloads the xcframework, and `import Pendo` builds.

## Follow-up (tracked in APP-154941)

Make `release-framework` idempotent so future CocoaPods Trunk flakes can be recovered with a simple CI rerun-from-failed:
- `upload-file-to-artifactory`: HEAD check before PUT
- `cocoapods-publish`: treat HTTP 409 (duplicate entry) as success

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/335)
<!-- Reviewable:end -->
