### PR TITLE
APP-155694 Fix android integration doc styling for XML block

### DIFF
--- a/android/pnddocs/native-android.md
+++ b/android/pnddocs/native-android.md
@@ -194,16 +194,16 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
 
 Add the following **activity** to the application **AndroidManifest.xml** in the `<Application>` tag:
 
-    ```xml
-    <activity android:name="sdk.pendo.io.activities.PendoGateActivity" android:launchMode="singleInstance" android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="YOUR_SCHEME_ID_HERE"/>
-        </intent-filter>
-    </activity>
-    ```
+```xml
+<activity android:name="sdk.pendo.io.activities.PendoGateActivity" android:launchMode="singleInstance" android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="YOUR_SCHEME_ID_HERE"/>
+    </intent-filter>
+</activity>
+```
 
 ## Step 5. Verify installation
 


### PR DESCRIPTION
## Summary
- Dedented the fenced XML code block in `android/pnddocs/native-android.md` (Step 3, Mobile device connectivity for testing). The fence was indented 4 spaces, which GitHub interpreted as an indented code block — so the literal ` ```xml ` and ` ``` ` rendered as text instead of being parsed as a fenced block.

Ticket: [APP-155694](https://pendo-io.atlassian.net/browse/APP-155694)

## Test plan
- [ ] View `android/pnddocs/native-android.md` on the PR's "Files changed" tab and confirm the XML block under Step 3 renders as a syntax-highlighted code block (no visible backticks).

[APP-155694]: https://pendo-io.atlassian.net/browse/APP-155694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/337)
<!-- Reviewable:end -->
