### PR TITLE
APP-155454 Document pendoSkipAccessibilityScan SwiftUI modifier

### DIFF
--- a/api-documentation/native-ios-apis.md
+++ b/api-documentation/native-ios-apis.md
@@ -700,7 +700,7 @@ struct PortfolioView: View {
                 }
             }
         }
-        .pendoSkipAccessibilityScan() // Prevents main-thread layout-invalidation loops/hangs on iOS 16+
+        .pendoSkipAccessibilityScan() // Prevents main-thread layout-invalidation loops/hangs on iOS 16
     }
 }
 ```

--- a/api-documentation/native-ios-apis.md
+++ b/api-documentation/native-ios-apis.md
@@ -35,6 +35,7 @@
 ### View
 [View.pendoEnableSwiftUI](#viewpendoenableswiftui) ⇒ `void` <br>
 [View.pendoRecognizeClickAnalytics](#viewpendorecognizeclickanalytics) ⇒ `void` <br>
+[View.pendoSkipAccessibilityScan](#viewpendoskipaccessibilityscan) ⇒ `some View`<br>
 [View.pendoTag](#viewpendotag) ⇒ `some View`<br>
 [View.trackPage](#viewtrackpage) ⇒ `some View`<br>
 
@@ -653,6 +654,55 @@ func pendoRecognizeClickAnalytics()-> some View;
 
 ```swift
 someView.pendoRecognizeClickAnalytics() -> some View;
+```
+</details>
+
+### `View.pendoSkipAccessibilityScan`
+
+> [!NOTE]
+> Available from SDK 3.13.2 on iOS 13 and above.
+
+```swift
+func pendoSkipAccessibilityScan() -> some View
+```
+
+>Instructs the Pendo SDK to skip the Phase 1 (accessibility-to-view-rect map) scan for the hosting view controller of this view.
+>
+>Use this API to prevent main-thread UI hangs when rendering complex, nested lazy containers (such as `LazyVStack` or `LazyHStack` inside another lazy view) that dynamically load/mutate their state during `.onAppear` on iOS 16+.
+>
+>**The Apple Bug:** Under the hood, SwiftUI's accessibility tree traversal (triggered on iOS 16+ when VoiceOver, Accessibility Inspector, or the Pendo scanner queries the page) can run into an infinite layout-invalidation loop if child elements are continuously materializing and updating state on appear.
+>
+>**What Pendo does:** By applying `.pendoSkipAccessibilityScan()`, you disable Pendo's accessibility scan for that specific screen. This stops Pendo from triggering the hang, while still running Pendo's Phase 2 reflection-based scan (meaning the page is still correctly identified in Page analytics and Page capture).
+>
+>**Limitations:** This modifier only stops **Pendo** from triggering the Apple SwiftUI bug. If a user turns on VoiceOver or a developer attaches Xcode's Accessibility Inspector to this screen, the app will still hang due to Apple's underlying layout engine defect.
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+<b>Class</b>: View
+<br><b>Kind</b>: extension class method
+<br><b>Returns</b>: some View
+<br>
+
+<b>Example</b>:
+
+```swift
+struct PortfolioView: View {
+    @State private var items: [Item] = []
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(items) { item in
+                    ItemRow(item: item)
+                        .onAppear {
+                            loadMoreIfNeeded(item)
+                        }
+                }
+            }
+        }
+        .pendoSkipAccessibilityScan() // Prevents main-thread layout-invalidation loops/hangs on iOS 16+
+    }
+}
 ```
 </details>
 

--- a/api-documentation/native-ios-apis.md
+++ b/api-documentation/native-ios-apis.md
@@ -666,13 +666,13 @@ someView.pendoRecognizeClickAnalytics() -> some View;
 func pendoSkipAccessibilityScan() -> some View
 ```
 
->Instructs the Pendo SDK to skip the Phase 1 (accessibility-to-view-rect map) scan for the hosting view controller of this view.
+>Instructs the Pendo SDK to skip the accessibility scan for the hosting view controller of this view.
 >
->Use this API to prevent main-thread UI hangs when rendering complex, nested lazy containers (such as `LazyVStack` or `LazyHStack` inside another lazy view) that dynamically load/mutate their state during `.onAppear` on iOS 16+.
+>Use this API to prevent main-thread UI hangs when rendering complex, nested lazy containers (such as `LazyVStack` or `LazyHStack` inside another lazy view) that dynamically load/mutate their state during `.onAppear` on iOS 16.
 >
->**The Apple Bug:** Under the hood, SwiftUI's accessibility tree traversal (triggered on iOS 16+ when VoiceOver, Accessibility Inspector, or the Pendo scanner queries the page) can run into an infinite layout-invalidation loop if child elements are continuously materializing and updating state on appear.
+>**The Apple Bug:** Under the hood, SwiftUI's accessibility tree traversal (triggered only on iOS 16 when VoiceOver, Accessibility Inspector, or the Pendo scanner queries the page) can run into an infinite layout-invalidation loop if child elements are continuously materializing and updating state on appear.
 >
->**What Pendo does:** By applying `.pendoSkipAccessibilityScan()`, you disable Pendo's accessibility scan for that specific screen. This stops Pendo from triggering the hang, while still running Pendo's Phase 2 reflection-based scan (meaning the page is still correctly identified in Page analytics and Page capture).
+>**What Pendo does:** By applying `.pendoSkipAccessibilityScan()`, you disable Pendo's accessibility scan for that specific screen. This stops Pendo from triggering the hang, while still running Pendo's reflection-based scan (meaning the page is still correctly identified in Page analytics and Page capture).
 >
 >**Limitations:** This modifier only stops **Pendo** from triggering the Apple SwiftUI bug. If a user turns on VoiceOver or a developer attaches Xcode's Accessibility Inspector to this screen, the app will still hang due to Apple's underlying layout engine defect.
 

--- a/api-documentation/native-ios-apis.md
+++ b/api-documentation/native-ios-apis.md
@@ -668,9 +668,9 @@ func pendoSkipAccessibilityScan() -> some View
 
 >Instructs the Pendo SDK to skip the accessibility scan for the hosting view controller of this view.
 >
->Use this API to prevent main-thread UI hangs when rendering complex, nested lazy containers (such as `LazyVStack` or `LazyHStack` inside another lazy view) that dynamically load/mutate their state during `.onAppear` on iOS 16.
+>Use this API to prevent main-thread UI hangs when rendering complex, nested lazy containers (such as `LazyVStack` or `LazyHStack` inside another lazy view) that dynamically load/mutate their state during `.onAppear` on iOS 26.
 >
->**The Apple Bug:** Under the hood, SwiftUI's accessibility tree traversal (triggered only on iOS 16 when VoiceOver, Accessibility Inspector, or the Pendo scanner queries the page) can run into an infinite layout-invalidation loop if child elements are continuously materializing and updating state on appear.
+>**The Apple Bug:** Under the hood, SwiftUI's accessibility tree traversal (triggered only on iOS 26 when VoiceOver, Accessibility Inspector, or the Pendo scanner queries the page) can run into an infinite layout-invalidation loop if child elements are continuously materializing and updating state on appear.
 >
 >**What Pendo does:** By applying `.pendoSkipAccessibilityScan()`, you disable Pendo's accessibility scan for that specific screen. This stops Pendo from triggering the hang, while still running Pendo's reflection-based scan (meaning the page is still correctly identified in Page analytics and Page capture).
 >
@@ -700,7 +700,7 @@ struct PortfolioView: View {
                 }
             }
         }
-        .pendoSkipAccessibilityScan() // Prevents main-thread layout-invalidation loops/hangs on iOS 16
+        .pendoSkipAccessibilityScan() // Prevents main-thread layout-invalidation loops/hangs on iOS 26
     }
 }
 ```

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -334,7 +334,7 @@ _Why aren't some elements being tagged correctly in SwiftUI?_
   ```
 <br>
 
-- [`pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) - Bypasses Pendo's Phase 1 accessibility scan for the view's hosting controller. This prevents main-thread layout-invalidation hangs on iOS 16+ when rendering complex, nested lazy containers (`LazyVStack`, `LazyHStack`) that load or mutate state on appear. Example:
+- [`pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) - Bypasses Pendo's accessibility scan for the view's hosting controller. This prevents main-thread layout-invalidation hangs on iOS 16 when rendering complex, nested lazy containers (`LazyVStack`, `LazyHStack`) that load or mutate state on appear. Example:
   ```swift
   ScrollView {
       LazyVStack {
@@ -375,14 +375,14 @@ _I have noticed performance issues in my app after integrating Pendo SDK. What s
 
 * **Optimizing Scanning Depth** - If performance issues persist, adjust the scan depth settings. Consult our support team to configure this setting for optimal performance.
 
-* **Main-Thread Hangs on Lazy Containers (Apple Bug FB21851974)** - If you experience UI hangs on iOS 16+ when rendering screens containing nested `LazyVStack` or `LazyHStack` that load or mutate state on `.onAppear`, this is due to an Apple bug in SwiftUI's accessibility layout invalidation when scanned by any accessibility client (such as VoiceOver, Accessibility Inspector, or the Pendo scanner). 
+* **Main-Thread Hangs on Lazy Containers (Apple Bug FB21851974)** - If you experience UI hangs on iOS 16 when rendering screens containing nested `LazyVStack` or `LazyHStack` that load or mutate state on `.onAppear`, this is due to an Apple bug in SwiftUI's accessibility layout invalidation when scanned by any accessibility client (such as VoiceOver, Accessibility Inspector, or the Pendo scanner). 
 
   To resolve this trigger, apply the [`.pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) modifier on the view:
   ```swift
   MyComplexScrollView()
       .pendoSkipAccessibilityScan()
   ```
-  This will completely bypass the accessibility scan phase for that view controller, avoiding the infinite invalidation loop, while still executing reflection-based Page identification so the screen remains normally discoverable and trackable.
+  This will completely bypass the accessibility scan for that view controller, avoiding the infinite invalidation loop, while still executing reflection-based Page identification so the screen remains normally discoverable and trackable.
   
 ## General Troubleshooting
 

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -334,6 +334,20 @@ _Why aren't some elements being tagged correctly in SwiftUI?_
   ```
 <br>
 
+- [`pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) - Bypasses Pendo's Phase 1 accessibility scan for the view's hosting controller. This prevents main-thread layout-invalidation hangs on iOS 16+ when rendering complex, nested lazy containers (`LazyVStack`, `LazyHStack`) that load or mutate state on appear. Example:
+  ```swift
+  ScrollView {
+      LazyVStack {
+          ForEach(items) { item in
+              ItemRow(item: item)
+                  .onAppear { loadMore(item) }
+          }
+      }
+  }
+  .pendoSkipAccessibilityScan()
+  ```
+<br>
+
 - `pendoRecognizeClickAnalytics()` - A Pendo-specific modifier to help recognize clickable views that are not automatically tagged. It applies Apple's native accessibility APIs under the hood to combine child elements and mark them as buttons. If you prefer not to use a Pendo API, or for better code clarity, you can apply these native modifiers yourself:
   ```swift
   .accessibilityElement(children: .combine)
@@ -360,6 +374,15 @@ _I have noticed performance issues in my app after integrating Pendo SDK. What s
     _Please note that in that case feature analytics will be based only on accessibility data._
 
 * **Optimizing Scanning Depth** - If performance issues persist, adjust the scan depth settings. Consult our support team to configure this setting for optimal performance.
+
+* **Main-Thread Hangs on Lazy Containers (Apple Bug FB21851974)** - If you experience UI hangs on iOS 16+ when rendering screens containing nested `LazyVStack` or `LazyHStack` that load or mutate state on `.onAppear`, this is due to an Apple bug in SwiftUI's accessibility layout invalidation when scanned by any accessibility client (such as VoiceOver, Accessibility Inspector, or the Pendo scanner). 
+
+  To resolve this trigger, apply the [`.pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) modifier on the view:
+  ```swift
+  MyComplexScrollView()
+      .pendoSkipAccessibilityScan()
+  ```
+  This will completely bypass the accessibility scan phase for that view controller, avoiding the infinite invalidation loop, while still executing reflection-based Page identification so the screen remains normally discoverable and trackable.
   
 ## General Troubleshooting
 

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -334,7 +334,7 @@ _Why aren't some elements being tagged correctly in SwiftUI?_
   ```
 <br>
 
-- [`pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) - Bypasses Pendo's accessibility scan for the view's hosting controller. This prevents main-thread layout-invalidation hangs on iOS 16 when rendering complex, nested lazy containers (`LazyVStack`, `LazyHStack`) that load or mutate state on appear. Example:
+- [`pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) - Bypasses Pendo's accessibility scan for the view's hosting controller. This prevents main-thread layout-invalidation hangs on iOS 26 when rendering complex, nested lazy containers (`LazyVStack`, `LazyHStack`) that load or mutate state on appear. Example:
   ```swift
   ScrollView {
       LazyVStack {
@@ -375,7 +375,7 @@ _I have noticed performance issues in my app after integrating Pendo SDK. What s
 
 * **Optimizing Scanning Depth** - If performance issues persist, adjust the scan depth settings. Consult our support team to configure this setting for optimal performance.
 
-* **Main-Thread Hangs on Lazy Containers (Apple Bug FB21851974)** - If you experience UI hangs on iOS 16 when rendering screens containing nested `LazyVStack` or `LazyHStack` that load or mutate state on `.onAppear`, this is due to an Apple bug in SwiftUI's accessibility layout invalidation when scanned by any accessibility client (such as VoiceOver, Accessibility Inspector, or the Pendo scanner). 
+* **Main-Thread Hangs on Lazy Containers (Apple Bug FB21851974)** - If you experience UI hangs on iOS 26 when rendering screens containing nested `LazyVStack` or `LazyHStack` that load or mutate state on `.onAppear`, this is due to an Apple bug in SwiftUI's accessibility layout invalidation when scanned by any accessibility client (such as VoiceOver, Accessibility Inspector, or the Pendo scanner). 
 
   To resolve this trigger, apply the [`.pendoSkipAccessibilityScan()`](/api-documentation/native-ios-apis.md#viewpendoskipaccessibilityscan) modifier on the view:
   ```swift


### PR DESCRIPTION
## Summary
* Added full API documentation for the new `.pendoSkipAccessibilityScan()` SwiftUI View modifier in `api-documentation/native-ios-apis.md`.
* Explained the layout-invalidation SwiftUI rendering hang (Apple Bug FB21851974) and how the modifier mitigates it on iOS 16+.
* Added troubleshooting steps and reference links in `ios/pnddocs/native-ios.md`.

## Test plan
- Verify that markdown links are correctly formatted and resolve properly to each other.
- Review the generated layout structure in both `.md` files to ensure seamless integration with the existing Pendo Mobile documentation.

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/338)
<!-- Reviewable:end -->
