### PR TITLE
APP-157034 Release version 3.13.5 to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pendo",
-            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.4.11866/pendo-ios-sdk-xcframework.3.13.4.11866.zip",
-            checksum: "519e56ae5752875c8a366ae72473167b508b259e63e699dfb17501642ba44dc5"
+            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.5.11895/pendo-ios-sdk-xcframework.3.13.5.11895.zip",
+            checksum: "66f5a291ef6ab7d82fccf7caa776fcd23bed82b8e82004380c4b863ac6c57837"
         ),
     ]
 )


### PR DESCRIPTION
## Context

Manual SPM release recovery for **3.13.5** after a CocoaPods Trunk outage left the `release-swift-package` job blocked on the 3.13.5 pipeline (build #11895). See [APP-157034](https://pendo-io.atlassian.net/browse/APP-157034). Same class of failure as the 3.13.1 recovery in APP-154941.

## Change

Point `Package.swift` at the 3.13.5.11895 xcframework artifact:

- `url` → `ios-sdk-release/3.13.5.11895/pendo-ios-sdk-xcframework.3.13.5.11895.zip`
- `checksum` → `66f5a291ef6ab7d82fccf7caa776fcd23bed82b8e82004380c4b863ac6c57837` (computed via `swift package compute-checksum`)

## Follow-up

After merge, push the annotated tag `3.13.5` at the merge commit:

```
git push --atomic origin master 3.13.5
```

## Acceptance Criteria

- [ ] `Package.swift` on master points to 3.13.5.11895 zip with correct SPM checksum
- [ ] Annotated tag `3.13.5` exists and points to the release commit
- [ ] SPM consumers using `.upToNextMinor(from: "3.13.0")` resolve `3.13.5`
- [ ] Smoke test: a fresh project resolves `3.13.5`, downloads the xcframework, and builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-157034]: https://pendo-io.atlassian.net/browse/APP-157034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/339)
<!-- Reviewable:end -->
