### PR TITLE
APP-157694 Release version 3.13.6 to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Pendo",
-            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.5.11895/pendo-ios-sdk-xcframework.3.13.5.11895.zip",
-            checksum: "66f5a291ef6ab7d82fccf7caa776fcd23bed82b8e82004380c4b863ac6c57837"
+            url: "https://software.mobile.pendo.io/artifactory/ios-sdk-release/3.13.6.11930/pendo-ios-sdk-xcframework.3.13.6.11930.zip",
+            checksum: "bae41a3b4e37c7f4c6acf50df808a5ac825cd75397d52df531ea6f6dc6e3d0e6"
         ),
     ]
 )


### PR DESCRIPTION
## Summary
- Manual SPM release recovery after CocoaPods Trunk outage on the 3.13.6 release pipeline (build #11930).
- Point `Package.swift` at the `3.13.6.11930` xcframework artifact with the SPM checksum computed via `swift package compute-checksum`.

## Test plan
- [ ] Verify that SPM resolves the package correctly with version `3.13.6.11930`.


Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/340)
<!-- Reviewable:end -->
