### PR TITLE
APP-158703 Bump documented Expo SDK support range from 41-54 to 41-56

### DIFF
--- a/android/pnddocs/expo_rn-android.md
+++ b/android/pnddocs/expo_rn-android.md
@@ -1,7 +1,7 @@
 # Expo Android using React Navigation
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Navigation 5+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Navigation 5+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/android/pnddocs/expo_rnn-android.md
+++ b/android/pnddocs/expo_rnn-android.md
@@ -1,7 +1,7 @@
 # Expo Android using React Native Navigation
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Native Navigation 6+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Native Navigation 6+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/android/pnddocs/expo_router-android.md
+++ b/android/pnddocs/expo_router-android.md
@@ -1,7 +1,7 @@
 # Expo Android using Expo Router
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Navigation 5+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Navigation 5+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/android/pnddocs/rn-android.md
+++ b/android/pnddocs/rn-android.md
@@ -1,7 +1,7 @@
 # React Native Android using React Navigation
 
 >[!NOTE]
->**Expo SDK** 41-54 using React Navigation 5+ is supported. See dedicated [Expo integration instructions](/android/pnddocs/expo_rn-android.md).
+>**Expo SDK** 41-56 using React Navigation 5+ is supported. See dedicated [Expo integration instructions](/android/pnddocs/expo_rn-android.md).
 
 >[!IMPORTANT]
 >- We support a codeless solution for React Native 0.66-0.84 using react-navigation 5+.

--- a/android/pnddocs/rnn-android.md
+++ b/android/pnddocs/rnn-android.md
@@ -1,7 +1,7 @@
 # React Native Android using React Native Navigation
 
 >[!NOTE]
->**Expo SDK** 41-54 using React Native Navigation 6+ is supported. See dedicated [Expo integration instructions](/android/pnddocs/expo_rnn-android.md).
+>**Expo SDK** 41-56 using React Native Navigation 6+ is supported. See dedicated [Expo integration instructions](/android/pnddocs/expo_rnn-android.md).
 
 >[!IMPORTANT]
 >- We support a codeless solution for React Native 0.66-0.84 using react-native-navigation 6+.

--- a/ios/pnddocs/expo_rn-ios.md
+++ b/ios/pnddocs/expo_rn-ios.md
@@ -1,7 +1,7 @@
 # Expo iOS using React Navigation
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Navigation 5+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Navigation 5+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/ios/pnddocs/expo_rnn-ios.md
+++ b/ios/pnddocs/expo_rnn-ios.md
@@ -1,7 +1,7 @@
 # Expo iOS using React Native Navigation
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Native Navigation 6+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Native Navigation 6+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/ios/pnddocs/expo_router-ios.md
+++ b/ios/pnddocs/expo_router-ios.md
@@ -1,7 +1,7 @@
 # Expo iOS using Expo Router
 
 >[!IMPORTANT]
->- **Expo SDK** 41-54 using React Navigation 5+ is supported by our codeless solution.
+>- **Expo SDK** 41-56 using React Navigation 5+ is supported by our codeless solution.
 >- **Expo Go** is not supported. Pendo SDK has a native plugin that is not part of the Expo Go app.
 Pendo can *only* be used in development builds. For more about development builds read [adding custom native code with development builds](https://docs.expo.dev/workflow/customizing/).
 >- Support for React Native's New Architecture (Fabric) is available starting from version 3.7.2.

--- a/ios/pnddocs/rn-ios.md
+++ b/ios/pnddocs/rn-ios.md
@@ -1,7 +1,7 @@
 # React Native iOS using React Navigation
 
 >[!NOTE]
->**Expo SDK** 41-54 using React Navigation 5+ is supported. See dedicated [Expo integration instructions](/ios/pnddocs/expo_rn-ios.md).
+>**Expo SDK** 41-56 using React Navigation 5+ is supported. See dedicated [Expo integration instructions](/ios/pnddocs/expo_rn-ios.md).
 
 >[!IMPORTANT]
 >- We support a codeless solution for React Native 0.66-0.84 using react-navigation 5+.

--- a/ios/pnddocs/rnn-ios.md
+++ b/ios/pnddocs/rnn-ios.md
@@ -1,7 +1,7 @@
 # React Native iOS using React Native Navigation
 
 >[!NOTE]
->**Expo SDK** 41-54 using React Native Navigation 6+ is supported. See dedicated [Expo integration instructions](/ios/pnddocs/expo_rnn-ios.md).
+>**Expo SDK** 41-56 using React Native Navigation 6+ is supported. See dedicated [Expo integration instructions](/ios/pnddocs/expo_rnn-ios.md).
 
 >[!IMPORTANT]
 >- We support a codeless solution for React Native 0.66-0.84 using react-native-navigation 6+.


### PR DESCRIPTION
## Summary
- Bump the documented Expo SDK support range from **41-54** to **41-56** across the public RN, RNN, Expo RN, and Expo Router integration guides.
- Expo SDK 55/56 compatibility with the Pendo RN SDK has been validated.
- Documentation-only change; touches both `android/` and `ios/` guide folders.

## Changes
| File | Description |
|------|-------------|
| `ios/pnddocs/rn-ios.md` | `Expo SDK 41-54` → `41-56` |
| `ios/pnddocs/rnn-ios.md` | `Expo SDK 41-54` → `41-56` |
| `ios/pnddocs/expo_rn-ios.md` | `Expo SDK 41-54` → `41-56` |
| `ios/pnddocs/expo_rnn-ios.md` | `Expo SDK 41-54` → `41-56` |
| `ios/pnddocs/expo_router-ios.md` | `Expo SDK 41-54` → `41-56` |
| `android/pnddocs/rn-android.md` | `Expo SDK 41-54` → `41-56` |
| `android/pnddocs/rnn-android.md` | `Expo SDK 41-54` → `41-56` |
| `android/pnddocs/expo_rn-android.md` | `Expo SDK 41-54` → `41-56` |
| `android/pnddocs/expo_rnn-android.md` | `Expo SDK 41-54` → `41-56` |
| `android/pnddocs/expo_router-android.md` | `Expo SDK 41-54` → `41-56` |

## Acceptance Criteria
- [x] All 10 doc pages read **Expo SDK 41-56** (no remaining `41-54` references)
- [x] Expo 55/56 compatibility confirmed with the Pendo RN SDK
- [x] PR opened against `master`

Jira: https://pendo-io.atlassian.net/browse/APP-158703

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/345)
<!-- Reviewable:end -->
