### PR TITLE
APP-158758 Document Flutter API

### DIFF
--- a/api-documentation/flutter-apis.md
+++ b/api-documentation/flutter-apis.md
@@ -19,6 +19,7 @@
 [getVisitorId](#getvisitorid) ⇒ `String` <br>
 [getAccountId](#getaccountid) ⇒ `String` <br>
 [setDebugMode](#setdebugmode) ⇒ `void`<br>
+[setSnapshotableWidgetTypes](#setsnapshotablewidgettypes) ⇒ `void` <br>
 
 ## PendoSDK APIs
 
@@ -389,5 +390,36 @@ static Future<void> setDebugMode(bool isDebugEnabled) async
 ```c#
 await PendoSDK.setDebugMode(true);
 await PendoSDK.setup("your.app.key", null);
+```
+</details>
+
+### `setSnapshotableWidgetTypes`
+
+```c#
+static void setSnapshotableWidgetTypes(Set<Type> types)
+```
+
+>Registers widget types that have no dedicated Session Replay extractor so they are captured as `<img>` render snapshots. Use this for **static** visual widgets such as `flutter_svg`'s `SvgPicture`. The snapshot is cached and reused across scans. For animated widgets, use [setAnimatedSnapshotableWidgetTypes](#setanimatedsnapshotablewidgettypes) instead.
+
+>Registered types are treated as images for privacy purposes: the `img` selector in your privacy configuration blocks/masks them just like any other image, so vector or custom content cannot bypass your privacy rules. Call this API before the widgets are scanned (typically right after `setup`).
+
+<details>
+    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary><br>
+
+<b>Class</b>: PendoSDK<br>
+<b>Kind</b>: static method<br>
+<b>Returns</b>: void<br>
+<br>
+
+| Param  | Type | Description |
+| :---: | :---: | :--- |
+| types | Set\<Type\> | The set of widget types to capture as static `<img>` render snapshots |
+
+<b>Example:</b>
+
+```c#
+import 'package:flutter_svg/flutter_svg.dart';
+
+PendoSDK.setSnapshotableWidgetTypes({SvgPicture});
 ```
 </details>

--- a/api-documentation/flutter-apis.md
+++ b/api-documentation/flutter-apis.md
@@ -20,6 +20,7 @@
 [getAccountId](#getaccountid) ⇒ `String` <br>
 [setDebugMode](#setdebugmode) ⇒ `void`<br>
 [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes) ⇒ `void` <br>
+[setAnimatedSnapshotableWidgetTypes](#setanimatedsnapshotablewidgettypes) ⇒ `void` <br>
 
 ## PendoSDK APIs
 
@@ -421,5 +422,37 @@ static void setSnapshotableWidgetTypes(Set<Type> types)
 import 'package:flutter_svg/flutter_svg.dart';
 
 PendoSDK.setSnapshotableWidgetTypes({SvgPicture});
+```
+</details>
+
+### `setAnimatedSnapshotableWidgetTypes`
+
+```c#
+static void setAnimatedSnapshotableWidgetTypes(Set<Type> types)
+```
+
+>Like [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes), but for **animated** widgets such as the `gif` package's `Gif` or Lottie. Registered types bypass the snapshot image cache, so each Session Replay scan re-captures the current frame and the widget animates (at the scan cadence) instead of freezing on its first captured frame. Use [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes) for static widgets so they stay cached.
+
+>Registered types are treated as images for privacy purposes: the `img` selector in your privacy configuration blocks/masks them just like any other image. Call this API before the widgets are scanned (typically right after `setup`).
+
+<details>
+    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary><br>
+
+<b>Class</b>: PendoSDK<br>
+<b>Kind</b>: static method<br>
+<b>Returns</b>: void<br>
+<br>
+
+| Param  | Type | Description |
+| :---: | :---: | :--- |
+| types | Set\<Type\> | The set of animated widget types to re-capture as `<img>` render snapshots on every scan |
+
+<b>Example:</b>
+
+```c#
+import 'package:gif/gif.dart';
+import 'package:lottie/lottie.dart';
+
+PendoSDK.setAnimatedSnapshotableWidgetTypes({Gif, LottieBuilder});
 ```
 </details>


### PR DESCRIPTION
## Summary
Adds the public-API reference entry for **`setSnapshotableWidgetTypes`** to `api-documentation/flutter-apis.md` (TOC link + section).

This Flutter API lets integrators register widget types that have no dedicated Session Replay extractor so they're captured as `<img>` render snapshots — for **static** visual widgets (e.g. `flutter_svg`'s `SvgPicture`). The snapshot is cached and reused across scans, and registered types honor the `img` privacy selector.

Introduced in flutterPlugin <https://github.com/pendo-io/flutterPlugin/pull/525|#525> / APP-155611.

Jira: APP-158758

## Notes
- Docs-only; matches the existing entry format in this file.
- Companion PR documents the animated variant (`setAnimatedSnapshotableWidgetTypes`, APP-158759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/346)
<!-- Reviewable:end -->
