### PR TITLE
APP-158759 Document Flutter setAnimatedSnapshotableWidgetTypes API

### DIFF
--- a/api-documentation/flutter-apis.md
+++ b/api-documentation/flutter-apis.md
@@ -20,6 +20,7 @@
 [getAccountId](#getaccountid) ⇒ `String` <br>
 [setDebugMode](#setdebugmode) ⇒ `void`<br>
 [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes) ⇒ `void` <br>
+[setAnimatedSnapshotableWidgetTypes](#setanimatedsnapshotablewidgettypes) ⇒ `void` <br>
 
 ## PendoSDK APIs
 
@@ -421,5 +422,37 @@ static void setSnapshotableWidgetTypes(Set<Type> types)
 import 'package:flutter_svg/flutter_svg.dart';
 
 PendoSDK.setSnapshotableWidgetTypes({SvgPicture});
+```
+</details>
+
+### `setAnimatedSnapshotableWidgetTypes`
+
+```c#
+static void setAnimatedSnapshotableWidgetTypes(Set<Type> types)
+```
+
+>Like [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes), but for **animated** widgets such as the `gif` package's `Gif` or Lottie. Registered types bypass the snapshot image cache, so each Session Replay scan re-captures the current frame and the widget animates (at the scan cadence) instead of freezing on its first captured frame. Use [setSnapshotableWidgetTypes](#setsnapshotablewidgettypes) for static widgets so they stay cached.
+
+>Registered types are treated as images for privacy purposes: the `img` selector in your privacy configuration blocks/masks them just like any other image. Call this API before the widgets are scanned (typically right after `setup`).
+
+<details>
+    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary><br>
+
+<b>Class</b>: PendoSDK<br>
+<b>Kind</b>: static method<br>
+<b>Returns</b>: void<br>
+<br>
+
+| Param  | Type | Description |
+| :---: | :---: | :--- |
+| types | Set\<Type\> | The set of animated widget types to re-capture as `<img>` render snapshots on every scan |
+
+<b>Example:</b>
+
+```c#
+import 'package:gif/gif.dart';
+import 'package:lottie/lottie.dart';
+
+PendoSDK.setAnimatedSnapshotableWidgetTypes({Gif, LottieBuilder});
 ```
 </details>


### PR DESCRIPTION
## Summary
Adds the public-API reference entry for **`setAnimatedSnapshotableWidgetTypes`** to `api-documentation/flutter-apis.md` (TOC link + section).

Like `setSnapshotableWidgetTypes`, but for **animated** widgets (e.g. the `gif` package's `Gif`, Lottie). Registered types **bypass the snapshot cache** so each Session Replay scan re-captures the current frame and the widget animates instead of freezing on its first captured frame. Same `img`-selector privacy gating.

Introduced in flutterPlugin <https://github.com/pendo-io/flutterPlugin/pull/525|#525> / APP-155612.

Jira: APP-158759

## Notes
- Docs-only.
- **Stacked on** APP-158758 (`setSnapshotableWidgetTypes` doc) to avoid a TOC/section conflict — base will auto-retarget to `master` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/347)
<!-- Reviewable:end -->
