### PR TITLE
APP-159323 doc: add React Native SPM integration guidelines

### DIFF
--- a/ios/pnddocs/expo_rn-ios.md
+++ b/ios/pnddocs/expo_rn-ios.md
@@ -48,6 +48,28 @@ In the `app.config.js` or `app.json`, add the following:
 ```
 This configuration enables Pendo to enter pair mode to tag Pages and Features.
 
+#### Swift Package Manager (SPM) Support (React Native >= 0.75)
+
+By default, `rn-pendo-sdk` uses CocoaPods to resolve the Pendo iOS SDK. If you are using React Native >= 0.75 and want to resolve the Pendo iOS SDK via Swift Package Manager (SPM), you can explicitly opt-in:
+
+Add `"ios-use-spm": true` to your plugin properties:
+```json
+{
+  "plugins": [
+    [
+      "rn-pendo-sdk",
+      {
+        "ios-scheme": "YOUR_IOS_SCHEME_ID",
+        "android-scheme": "YOUR_ANDROID_SCHEME_ID",
+        "ios-use-spm": true
+      }
+    ]
+  ]
+}
+```
+
+This configuration automatically injects the SPM enablement flag and dynamic framework signing helper into the generated `Podfile` during `npx expo prebuild` (or EAS Build), preventing `dyld: Library not loaded` runtime crashes.
+
 ## Step 3. Production bundle - modify Javascript minification
 
 In the `metro.config.js` file, add the following:

--- a/ios/pnddocs/expo_rnn-ios.md
+++ b/ios/pnddocs/expo_rnn-ios.md
@@ -48,6 +48,28 @@ In the `app.config.js` or `app.json`, add the following:
 ```
 This configuration enables Pendo to enter pair mode to tag Pages and Features.
 
+#### Swift Package Manager (SPM) Support (React Native >= 0.75)
+
+By default, `rn-pendo-sdk` uses CocoaPods to resolve the Pendo iOS SDK. If you are using React Native >= 0.75 and want to resolve the Pendo iOS SDK via Swift Package Manager (SPM), you can explicitly opt-in:
+
+Add `"ios-use-spm": true` to your plugin properties:
+```json
+{
+  "plugins": [
+    [
+      "rn-pendo-sdk",
+      {
+        "ios-scheme": "YOUR_IOS_SCHEME_ID",
+        "android-scheme": "YOUR_ANDROID_SCHEME_ID",
+        "ios-use-spm": true
+      }
+    ]
+  ]
+}
+```
+
+This configuration automatically injects the SPM enablement flag and dynamic framework signing helper into the generated `Podfile` during `npx expo prebuild` (or EAS Build), preventing `dyld: Library not loaded` runtime crashes.
+
 ## Step 3. Production bundle - modify Javascript minification
 
 In the `metro.config.js` file, add the following:

--- a/ios/pnddocs/expo_router-ios.md
+++ b/ios/pnddocs/expo_router-ios.md
@@ -48,6 +48,28 @@ In the `app.config.js` or `app.json`, add the following:
 ```
 This configuration enables Pendo to enter pair mode to tag Pages and Features.
 
+#### Swift Package Manager (SPM) Support (React Native >= 0.75)
+
+By default, `rn-pendo-sdk` uses CocoaPods to resolve the Pendo iOS SDK. If you are using React Native >= 0.75 and want to resolve the Pendo iOS SDK via Swift Package Manager (SPM), you can explicitly opt-in:
+
+Add `"ios-use-spm": true` to your plugin properties:
+```json
+{
+  "plugins": [
+    [
+      "rn-pendo-sdk",
+      {
+        "ios-scheme": "YOUR_IOS_SCHEME_ID",
+        "android-scheme": "YOUR_ANDROID_SCHEME_ID",
+        "ios-use-spm": true
+      }
+    ]
+  ]
+}
+```
+
+This configuration automatically injects the SPM enablement flag and dynamic framework signing helper into the generated `Podfile` during `npx expo prebuild` (or EAS Build), preventing `dyld: Library not loaded` runtime crashes.
+
 ## Step 3. Production bundle - modify Javascript minification
 
 In the `metro.config.js` file, add the following:

--- a/ios/pnddocs/rn-ios.md
+++ b/ios/pnddocs/rn-ios.md
@@ -31,6 +31,35 @@
     pod install
     ```
 
+    #### Swift Package Manager (SPM) Support (React Native >= 0.75)
+
+    By default, `rn-pendo-sdk` uses CocoaPods to resolve the Pendo iOS SDK. If you are using React Native >= 0.75 and want to resolve the Pendo iOS SDK via Swift Package Manager (SPM), you can explicitly opt-in:
+
+    a. At the top of your `ios/Podfile` (before any `target` block), add the SPM enablement flag and require our SPM helper script:
+
+    ```ruby
+    $RNPendoEnableSPM = true
+    require_relative '../node_modules/rn-pendo-sdk/scripts/pendo_spm_fix'
+    ```
+
+    b. Inside your `Podfile`'s `post_install` block, call `pendo_fix_spm_signing(installer)` to automate dynamic framework embedding and signing:
+
+    ```ruby
+    post_install do |installer|
+      # ... other post install hooks (e.g. react_native_post_install) ...
+      pendo_fix_spm_signing(installer)
+    end
+    ```
+
+    c. Run `pod install` in your `ios/` folder:
+
+    ```shell
+    cd ios && pod install
+    ```
+
+>[!NOTE]
+>Because `Pendo.framework` is a pre-compiled dynamic binary framework, Xcode does not automatically embed and sign it when resolved via SPM inside a subproject (`Pods.xcodeproj`). The `pendo_fix_spm_signing(installer)` helper script automates adding the necessary "Embed & Sign" build phase to your main application target to prevent `dyld: Library not loaded` runtime crashes.
+
 3. **Modify Javascript minification**
 
     When bundling for production, React Native minifies class and function names to reduce the size of the bundle. This means there is no access to the original component names that are used for the codeless solution.

--- a/ios/pnddocs/rnn-ios.md
+++ b/ios/pnddocs/rnn-ios.md
@@ -30,7 +30,36 @@
     ```shell
     pod install
     ```
-    
+
+    #### Swift Package Manager (SPM) Support (React Native >= 0.75)
+
+    By default, `rn-pendo-sdk` uses CocoaPods to resolve the Pendo iOS SDK. If you are using React Native >= 0.75 and want to resolve the Pendo iOS SDK via Swift Package Manager (SPM), you can explicitly opt-in:
+
+    a. At the top of your `ios/Podfile` (before any `target` block), add the SPM enablement flag and require our SPM helper script:
+
+    ```ruby
+    $RNPendoEnableSPM = true
+    require_relative '../node_modules/rn-pendo-sdk/scripts/pendo_spm_fix'
+    ```
+
+    b. Inside your `Podfile`'s `post_install` block, call `pendo_fix_spm_signing(installer)` to automate dynamic framework embedding and signing:
+
+    ```ruby
+    post_install do |installer|
+      # ... other post install hooks (e.g. react_native_post_install) ...
+      pendo_fix_spm_signing(installer)
+    end
+    ```
+
+    c. Run `pod install` in your `ios/` folder:
+
+    ```shell
+    cd ios && pod install
+    ```
+
+>[!NOTE]
+>Because `Pendo.framework` is a pre-compiled dynamic binary framework, Xcode does not automatically embed and sign it when resolved via SPM inside a subproject (`Pods.xcodeproj`). The `pendo_fix_spm_signing(installer)` helper script automates adding the necessary "Embed & Sign" build phase to your main application target to prevent `dyld: Library not loaded` runtime crashes.
+
 3. **Modify Javascript minification**
 
     When bundling for production, React Native minifies class and function names to reduce the size of the bundle. This means there is no access to the original component names that are used for the codeless solution.


### PR DESCRIPTION
## Summary
This PR adds Swift Package Manager (SPM) support integration guidelines for `react-native-pendo-sdk` to the `pendo-mobile-ios` documentation.

It covers:
1. **React Native & React Native Navigation (Bare Workflow)**: Manual `Podfile` configuration using `$RNPendoEnableSPM = true` and the dynamic framework signing helper script `pendo_fix_spm_signing(installer)`.
2. **Expo (Managed Workflow / EAS Build)**: Automatic SPM configuration via the `"ios-use-spm": true` property in `app.json` plugin properties.

## Test plan
Verified that all modified markdown files render correctly and match the latest SPM opt-in strategy implemented in `react-native-pendo-sdk`.

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/348)
<!-- Reviewable:end -->
