### PR TITLE
APP-159913 Fix stale SDK version examples and broken Flutter setup() sample

### DIFF
--- a/android/pnddocs/android_sdk_manual_installation.md
+++ b/android/pnddocs/android_sdk_manual_installation.md
@@ -16,10 +16,10 @@ If you are having problems installing the SDK, please follow these steps:
     } 
     ```
 
-4. Specify the version number for the Pendo dependency in the gradle file. <br>For example, for version 3.11.0.x it should look like this: 
+4. Specify the version number for the Pendo dependency in the gradle file. <br>For example, for version 3.13.7.x it should look like this: 
 
     ```java
-    implementation (group:'sdk.pendo.io' , name:'pendoIO', version:'3.11.0.x', changing:true)
+    implementation (group:'sdk.pendo.io' , name:'pendoIO', version:'3.13.7.x', changing:true)
     ```
 
 ## Developer documentation

--- a/android/pnddocs/native-android.md
+++ b/android/pnddocs/native-android.md
@@ -52,7 +52,7 @@
 
     ```shell
     dependencies {
-       implementation group:'sdk.pendo.io' , name:'pendoIO', version:'3.12.+', changing:true
+       implementation group:'sdk.pendo.io' , name:'pendoIO', version:'3.13.+', changing:true
     }
     ```
 

--- a/migration-docs/flutter-2.x-to-3.x-migration.md
+++ b/migration-docs/flutter-2.x-to-3.x-migration.md
@@ -87,7 +87,7 @@ await PendoFlutterPlugin.startSession('someAppKey', pendoParams);
 
 ```dart
 // establish connection to server
-await PendoFlutterPlugin.setup('someAppKey'
+await PendoFlutterPlugin.setup('someAppKey',
                                 null // pendo app params
 );
 
@@ -113,7 +113,7 @@ Call `setup` instead of `initSDKWithoutVisitor`.
 
 ```dart
 // establish connection to server
-await PendoFlutterPlugin.initSDKWithoutVisitor('someAppKey'
+await PendoFlutterPlugin.initSDKWithoutVisitor('someAppKey',
                 null // pendo app params
 );
 ```
@@ -123,7 +123,7 @@ await PendoFlutterPlugin.initSDKWithoutVisitor('someAppKey'
 
 ```dart
 // establish connection to server
-await PendoFlutterPlugin.setup('someAppKey'
+await PendoFlutterPlugin.setup('someAppKey',
             null // pendo app params
 );
 ```

--- a/other/native-with-flutter-components.md
+++ b/other/native-with-flutter-components.md
@@ -69,7 +69,7 @@ In the terminal, run: `flutter pub get`
 
     ```java
     dependencies {
-        implementation group:'sdk.pendo.io' , name:'pendoIO', version:'3.11.+', changing:true
+        implementation group:'sdk.pendo.io' , name:'pendoIO', version:'3.13.+', changing:true
     }
     ```
 


### PR DESCRIPTION
## Summary
- Bump stale Pendo SDK dependency-version examples so customers who copy them resolve to the current 3.13.x line.
- Fix a syntactically broken Flutter `setup()` / `initSDKWithoutVisitor` code sample (missing argument separator).

## Changes
| File | Description |
|------|-------------|
| `android/pnddocs/native-android.md` | Gradle dynamic-version example `3.12.+` → `3.13.+` |
| `other/native-with-flutter-components.md` | Gradle dynamic-version example `3.11.+` → `3.13.+` |
| `android/pnddocs/android_sdk_manual_installation.md` | Manual-install example `3.11.0.x` → `3.13.7.x` (keeps the 4-segment `version.build` placeholder pattern intentionally) |
| `migration-docs/flutter-2.x-to-3.x-migration.md` | Add missing comma in 3 `setup()`/`initSDKWithoutVisitor` Dart samples |

## Acceptance Criteria
- [x] Gradle dynamic-version examples resolve to the current 3.13.x line
- [x] Manual-install example keeps the 4-segment build-number pattern, bumped to a current version
- [x] Flutter `setup()` / `initSDKWithoutVisitor` samples are valid Dart (comma between args)
- [x] No remaining `3.11.`/`3.12.` dependency-version examples in the touched files

Jira: [APP-159913](https://pendo-io.atlassian.net/browse/APP-159913)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-159913]: https://pendo-io.atlassian.net/browse/APP-159913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/pendo-mobile-sdk/349)
<!-- Reviewable:end -->
