### PR TITLE
APP-162098 Document MAUI SR Privacy Configuration API

### DIFF
--- a/android/pnddocs/xamarin_maui-android.md
+++ b/android/pnddocs/xamarin_maui-android.md
@@ -167,7 +167,7 @@ Review the Android Studio logcat and look for the following message:
 
 ## Session Replay privacy
 
-Session Replay privacy is configured server-side through a preset (for example, masking all text or masking input fields only). You can override that preset on individual elements from your app code — declaratively in XAML or imperatively in C# — using the `PendoSRPrivacyAction` enum (`Mask`, `Unmask`, `Block`):
+Session Replay privacy is configured server-side through a preset (for example, masking all text or masking input fields only). You can override that preset on individual elements from your app code — declaratively in XAML or imperatively in C# — using the `PendoSRPrivacyAction` enum (`Mask`, `Unmask`, `Block`, `None`):
 
 ```c#
 using PendoMAUIPlugin;
@@ -182,7 +182,7 @@ balanceLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Mask);
 <Label Text="Balance: $42,850.00" pendo:PendoSR.ReplayPrivacy="Mask" />
 ```
 
-`Mask`/`Unmask` affect text only; use `Block` to hide images, media, or whole regions. Actions cascade to descendants, `Block` is terminal, and sensitive inputs are always masked. This element-level configuration applies to individual element instances and is currently available on Android. For the full reference, cascade rules, and safety rails, see [Session Replay — Privacy Configuration](/api-documentation/xamarin-maui-apis.md#session-replay--privacy-configuration) in the API documentation.
+`Mask`/`Unmask` affect text only; use `Block` to hide images, media, or whole regions; apply `None` to remove a rule so the element falls back to its inherited action or the preset. Actions cascade to descendants, `Block` is terminal, and sensitive inputs are always masked. This element-level configuration applies to individual element instances and is currently available on Android. For the full reference, cascade rules, and safety rails, see [Session Replay — Privacy Configuration](/api-documentation/xamarin-maui-apis.md#session-replay--privacy-configuration) in the API documentation.
 
 ## Developer documentation
 

--- a/android/pnddocs/xamarin_maui-android.md
+++ b/android/pnddocs/xamarin_maui-android.md
@@ -165,6 +165,24 @@ Review the Android Studio logcat and look for the following message:
 4. Select the `Install Settings tab` and follow the instructions under `Verify Your Installation` to ensure you have successfully integrated the Pendo SDK.
 5. Confirm that you can see your app as `Integrated` under <a href="https://app.pendo.io/admin" target="_blank">subscription settings</a>.
 
+## Session Replay privacy
+
+Session Replay privacy is configured server-side through a preset (for example, masking all text or masking input fields only). You can override that preset on individual elements from your app code — declaratively in XAML or imperatively in C# — using the `PendoSRPrivacyAction` enum (`Mask`, `Unmask`, `Block`):
+
+```c#
+using PendoMAUIPlugin;
+
+// Mask the account balance label
+balanceLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Mask);
+```
+
+```xml
+<!-- Declare the Pendo namespace on your page's root element:
+     xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin" -->
+<Label Text="Balance: $42,850.00" pendo:PendoSR.ReplayPrivacy="Mask" />
+```
+
+`Mask`/`Unmask` affect text only; use `Block` to hide images, media, or whole regions. Actions cascade to descendants, `Block` is terminal, and sensitive inputs are always masked. This element-level configuration applies to individual element instances and is currently available on Android. For the full reference, cascade rules, and safety rails, see [Session Replay — Privacy Configuration](/api-documentation/xamarin-maui-apis.md#session-replay--privacy-configuration) in the API documentation.
 
 ## Developer documentation
 

--- a/api-documentation/xamarin-maui-apis.md
+++ b/api-documentation/xamarin-maui-apis.md
@@ -22,6 +22,15 @@
 [SetDebugMode](#setdebugmode) ⇒ `void`<br>
 [ScreenContentChanged](#screencontentchanged) ⇒ `void`<br>
 
+### Session Replay — Privacy Configuration
+[PendoSRPrivacyAction](#pendosrprivacyaction) ⇒ `enum` <br>
+[VisualElement.ApplyPendoSRPrivacy](#applypendosrprivacy) ⇒ `void` <br>
+[VisualElement.ClearPendoSRPrivacy](#clearpendosrprivacy) ⇒ `void` <br>
+[PendoSR.ReplayPrivacy](#pendosrreplayprivacy) (XAML attached property) <br>
+[Actions & behavior](#actions--behavior) <br>
+[Cascade & inheritance](#cascade--inheritance) <br>
+[Safety rails](#safety-rails) <br>
+
 ## IPendoInterface APIs
 
 ### `IPendoService`
@@ -484,3 +493,198 @@ void ScreenContentChanged()
 Pendo.ScreenContentChanged();
 ```
 </details>
+
+<br>
+
+## Session Replay — Privacy Configuration
+
+> [!IMPORTANT]
+> Session Replay privacy is first configured server-side through a **preset** (for example, masking all text, or masking input fields only). The APIs below let you override that preset on individual elements from your app code — imperatively with C# `VisualElement` extension methods, or declaratively with the `PendoSR.ReplayPrivacy` XAML attached property. All APIs live in the `PendoMAUIPlugin` namespace.
+
+> An element's privacy is expressed with the `PendoSRPrivacyAction` enum: `Mask`, `Unmask`, or `Block`. An action applies to the element it is set on and **cascades down** to its descendants, unless a descendant sets its own action (see [Cascade & inheritance](#cascade--inheritance)).
+
+> [!NOTE]
+> This element-level API applies privacy rules to individual element **instances** and is currently available on **Android**.
+
+### `PendoSRPrivacyAction`
+
+```c#
+public enum PendoSRPrivacyAction { Mask, Unmask, Block }
+```
+
+> The value passed to every element-level privacy API.
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+<br>
+
+<b>Enum:</b> PendoSRPrivacyAction
+<br><b>Namespace:</b> PendoMAUIPlugin
+<br>
+
+| Value | Effect |
+| :---: | :--- |
+| Mask | Redacts the element's **text**, which is rendered as asterisks in the replay. Text-only — does not affect images or media. |
+| Unmask | Reveals **text** that the active preset would otherwise mask. Text-only — does not reveal a blocked image or media. |
+| Block | Replaces the element (text, image, container, or media) with a layout-preserving gray placeholder, so its content is never captured. Also suppresses the replay of touch interactions over the element's bounds. |
+
+> [!NOTE]
+> `Mask` and `Unmask` affect **text only**. Images and other media are controlled by `Block` together with the backend preset. To hide an image or a region, use `Block`.
+
+</details>
+
+## Imperative API (C#)
+
+### `ApplyPendoSRPrivacy`
+
+```c#
+public static void ApplyPendoSRPrivacy(this VisualElement element, PendoSRPrivacyAction action)
+```
+
+> C# extension on `Microsoft.Maui.Controls.VisualElement` that sets a Session Replay privacy action on an element instance, overriding the active preset for that element and its descendants.
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+<br>
+
+<b>Class:</b> PendoSRPrivacyExtensions
+<br><b>Namespace:</b> PendoMAUIPlugin
+<br><b>Kind:</b> extension method on VisualElement
+<br><b>Returns:</b> void
+<br>
+
+| Param  | Type | Description |
+| :---: | :---: | :--- |
+| action | PendoSRPrivacyAction | The privacy action to apply (`Mask`, `Unmask`, or `Block`) |
+
+<b>Example:</b>
+
+```c#
+using PendoMAUIPlugin;
+
+// Redact the account balance text
+balanceLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Mask);
+
+// Reveal marketing copy the preset would otherwise mask
+promoLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Unmask);
+
+// Hide an entire payment section (text, images, and media)
+paymentLayout.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Block);
+```
+</details>
+
+### `ClearPendoSRPrivacy`
+
+```c#
+public static void ClearPendoSRPrivacy(this VisualElement element)
+```
+
+> C# extension on `Microsoft.Maui.Controls.VisualElement` that removes any privacy action previously set on the element instance. After clearing, the element falls back to its inherited action (from an ancestor) or to the active preset.
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+<br>
+
+<b>Class:</b> PendoSRPrivacyExtensions
+<br><b>Namespace:</b> PendoMAUIPlugin
+<br><b>Kind:</b> extension method on VisualElement
+<br><b>Returns:</b> void
+<br>
+
+<b>Example:</b>
+
+```c#
+using PendoMAUIPlugin;
+
+// Remove a previously applied rule; the element reverts to inherited/preset behavior
+balanceLabel.ClearPendoSRPrivacy();
+```
+</details>
+
+## Declarative API (XAML)
+
+### `PendoSR.ReplayPrivacy`
+
+```xml
+<Label pendo:PendoSR.ReplayPrivacy="Mask" ... />
+```
+
+> XAML attached property that sets a Session Replay privacy action directly in markup, overriding the active preset for that element and its descendants. From a developer's perspective this property is set-only. Declare the Pendo XAML namespace on the page's root element before using it:
+
+```xml
+xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin"
+```
+
+<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
+
+<br>
+
+<b>Class:</b> PendoSR
+<br><b>Namespace:</b> PendoMAUIPlugin
+<br><b>Kind:</b> XAML attached property (set-only)
+<br>
+
+| Attribute | Value | Description |
+| :---: | :---: | :--- |
+| pendo:PendoSR.ReplayPrivacy | Mask \| Unmask \| Block | The privacy action to apply to the element |
+
+<b>Example:</b>
+
+```xml
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin">
+
+    <VerticalStackLayout>
+
+        <!-- Redact text -->
+        <Label Text="Balance: $42,850.00" pendo:PendoSR.ReplayPrivacy="Mask" />
+
+        <!-- Reveal text the preset would mask -->
+        <Label Text="Public marketing copy — safe to show" pendo:PendoSR.ReplayPrivacy="Unmask" />
+
+        <!-- Hide a whole payment region (text, images, and media) -->
+        <VerticalStackLayout pendo:PendoSR.ReplayPrivacy="Block">
+            <!-- payment fields... -->
+        </VerticalStackLayout>
+
+    </VerticalStackLayout>
+</ContentPage>
+```
+</details>
+
+## Actions & behavior
+
+> - **Mask** — redacts the element's text, rendered as asterisks. Text-only.
+> - **Unmask** — reveals text that the preset would otherwise mask. Text-only.
+> - **Block** — replaces the element with a layout-preserving gray placeholder and suppresses the replay of touch interactions over its bounds. Works for any element type: text, image, container, or media.
+>
+> `Mask` and `Unmask` **never** affect images or media. Image and media capture is governed by `Block` and the backend preset. To hide an image or region, use `Block`. `Mask` does not gray out an image, and `Unmask` does not lift an image block.
+
+## Cascade & inheritance
+
+> A privacy action set on an element applies to that element **and cascades down** the visual tree to all of its descendants, until a descendant overrides it with its own action.
+
+> [!IMPORTANT]
+> **`Block` is terminal.** Once an ancestor is blocked, a descendant `Unmask` (or `Mask`) cannot override the inherited `Block` — the blocked subtree stays a placeholder.
+
+<b>Example:</b>
+
+```c#
+// Container is blocked -> the whole subtree is a gray placeholder
+rootLayout.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Block);
+
+// This has NO effect: a descendant cannot escape an inherited Block
+childLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Unmask); // still blocked
+```
+
+```c#
+// Container masks all text; a specific child is revealed
+formLayout.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Mask);
+promoLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Unmask); // this child's text is shown
+```
+
+## Safety rails
+
+> [!CAUTION]
+> Sensitive inputs are **always masked**, even under an explicit `Unmask`. This safety rail cannot be overridden. It covers password fields, credit-card fields, email and phone inputs, and any field with an autofill hint. Use `Block` if you additionally want such a field rendered as a placeholder.

--- a/api-documentation/xamarin-maui-apis.md
+++ b/api-documentation/xamarin-maui-apis.md
@@ -25,7 +25,6 @@
 ### Session Replay — Privacy Configuration
 [PendoSRPrivacyAction](#pendosrprivacyaction) ⇒ `enum` <br>
 [VisualElement.ApplyPendoSRPrivacy](#applypendosrprivacy) ⇒ `void` <br>
-[VisualElement.ClearPendoSRPrivacy](#clearpendosrprivacy) ⇒ `void` <br>
 [PendoSR.ReplayPrivacy](#pendosrreplayprivacy) (XAML attached property) <br>
 [Actions & behavior](#actions--behavior) <br>
 [Cascade & inheritance](#cascade--inheritance) <br>
@@ -501,7 +500,7 @@ Pendo.ScreenContentChanged();
 > [!IMPORTANT]
 > Session Replay privacy is first configured server-side through a **preset** (for example, masking all text, or masking input fields only). The APIs below let you override that preset on individual elements from your app code — imperatively with C# `VisualElement` extension methods, or declaratively with the `PendoSR.ReplayPrivacy` XAML attached property. All APIs live in the `PendoMAUIPlugin` namespace.
 
-> An element's privacy is expressed with the `PendoSRPrivacyAction` enum: `Mask`, `Unmask`, or `Block`. An action applies to the element it is set on and **cascades down** to its descendants, unless a descendant sets its own action (see [Cascade & inheritance](#cascade--inheritance)).
+> An element's privacy is expressed with the `PendoSRPrivacyAction` enum: `Mask`, `Unmask`, `Block`, or `None`. An action applies to the element it is set on and **cascades down** to its descendants, unless a descendant sets its own action (see [Cascade & inheritance](#cascade--inheritance)).
 
 > [!NOTE]
 > This element-level API applies privacy rules to individual element **instances** and is currently available on **Android**.
@@ -509,7 +508,7 @@ Pendo.ScreenContentChanged();
 ### `PendoSRPrivacyAction`
 
 ```c#
-public enum PendoSRPrivacyAction { Mask, Unmask, Block }
+public enum PendoSRPrivacyAction { Mask, Unmask, Block, None }
 ```
 
 > The value passed to every element-level privacy API.
@@ -527,6 +526,7 @@ public enum PendoSRPrivacyAction { Mask, Unmask, Block }
 | Mask | Redacts the element's **text**, which is rendered as asterisks in the replay. Text-only — does not affect images or media. |
 | Unmask | Reveals **text** that the active preset would otherwise mask. Text-only — does not reveal a blocked image or media. |
 | Block | Replaces the element (text, image, container, or media) with a layout-preserving gray placeholder, so its content is never captured. Also suppresses the replay of touch interactions over the element's bounds. |
+| None | Removes any privacy action previously set on the element, so it falls back to its inherited action (from an ancestor) or the active preset. Not a force-reveal — use `Unmask` to reveal text under a masked ancestor. |
 
 > [!NOTE]
 > `Mask` and `Unmask` affect **text only**. Images and other media are controlled by `Block` together with the backend preset. To hide an image or a region, use `Block`.
@@ -555,7 +555,7 @@ public static void ApplyPendoSRPrivacy(this VisualElement element, PendoSRPrivac
 
 | Param  | Type | Description |
 | :---: | :---: | :--- |
-| action | PendoSRPrivacyAction | The privacy action to apply (`Mask`, `Unmask`, or `Block`) |
+| action | PendoSRPrivacyAction | The privacy action to apply (`Mask`, `Unmask`, `Block`, or `None`) |
 
 <b>Example:</b>
 
@@ -570,34 +570,9 @@ promoLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Unmask);
 
 // Hide an entire payment section (text, images, and media)
 paymentLayout.ApplyPendoSRPrivacy(PendoSRPrivacyAction.Block);
-```
-</details>
-
-### `ClearPendoSRPrivacy`
-
-```c#
-public static void ClearPendoSRPrivacy(this VisualElement element)
-```
-
-> C# extension on `Microsoft.Maui.Controls.VisualElement` that removes any privacy action previously set on the element instance. After clearing, the element falls back to its inherited action (from an ancestor) or to the active preset.
-
-<details>    <summary> <b>Details</b><i> - Click to expand or collapse</i></summary>
-
-<br>
-
-<b>Class:</b> PendoSRPrivacyExtensions
-<br><b>Namespace:</b> PendoMAUIPlugin
-<br><b>Kind:</b> extension method on VisualElement
-<br><b>Returns:</b> void
-<br>
-
-<b>Example:</b>
-
-```c#
-using PendoMAUIPlugin;
 
 // Remove a previously applied rule; the element reverts to inherited/preset behavior
-balanceLabel.ClearPendoSRPrivacy();
+balanceLabel.ApplyPendoSRPrivacy(PendoSRPrivacyAction.None);
 ```
 </details>
 
@@ -626,7 +601,7 @@ xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin"
 
 | Attribute | Value | Description |
 | :---: | :---: | :--- |
-| pendo:PendoSR.ReplayPrivacy | Mask \| Unmask \| Block | The privacy action to apply to the element |
+| pendo:PendoSR.ReplayPrivacy | Mask \| Unmask \| Block \| None | The privacy action to apply to the element |
 
 <b>Example:</b>
 
@@ -658,6 +633,7 @@ xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin"
 > - **Mask** — redacts the element's text, rendered as asterisks. Text-only.
 > - **Unmask** — reveals text that the preset would otherwise mask. Text-only.
 > - **Block** — replaces the element with a layout-preserving gray placeholder and suppresses the replay of touch interactions over its bounds. Works for any element type: text, image, container, or media.
+> - **None** — removes any rule previously set on the element, so it falls back to its inherited action or the active preset. Not a force-reveal.
 >
 > `Mask` and `Unmask` **never** affect images or media. Image and media capture is governed by `Block` and the backend preset. To hide an image or region, use `Block`. `Mask` does not gray out an image, and `Unmask` does not lift an image block.
 


### PR DESCRIPTION
## Summary

Adds customer-facing documentation for the new **MAUI** element-level Session Replay (SR) privacy API (Android platform delegation), mirroring the Android SR-privacy docs.

- **`api-documentation/xamarin-maui-apis.md`** — new "Session Replay — Privacy Configuration" section covering:
  - `PendoPrivacyAction` enum (`Mask` / `Unmask` / `Block`)
  - Imperative C#: `VisualElement.ApplyPendoSRPrivacy` / `VisualElement.ClearPendoSRPrivacy` extension methods
  - Declarative XAML: the `PendoSR.ReplayPrivacy` attached property (`xmlns:pendo="clr-namespace:PendoMAUIPlugin;assembly=PendoMAUIPlugin"`)
  - Behavior semantics: actions, text-only Mask/Unmask, cascade/inheritance, Block-terminal, and always-on safety rails
- **`android/pnddocs/xamarin_maui-android.md`** — short "Session Replay privacy" subsection linking to the API reference.

Structure/tone mirrors the Android sibling PR #355, adapted to MAUI's C# + XAML surface.

## Scope
Element (instance) level privacy configuration, available on Android. Class-level configuration and iOS are out of scope for this documentation.

## Docs-only — no code
No SDK source code was changed. Documentation only.

## Design doc
https://pendo-io.atlassian.net/wiki/spaces/DEV/pages/5053939735