### PR TITLE
APP-161150 Add iOS analytics & Session Replay data handling and offline support doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For integration using signed metadata see: [JWT integration instructions](https:
 - [Configuring CNAME Hostnames](https://support.pendo.io/hc/en-us/articles/360047607631-Configure-CNAME-for-Pendo-Mobile)
 - [Work with dynamic content in your mobile app](https://support.pendo.io/hc/en-us/articles/24836902488219-Work-with-dynamic-content-in-your-mobile-app)
 - [Mobile offline support analytics](https://support.pendo.io/hc/en-us/articles/360043016412-Mobile-offline-support-for-analytics)
+- [Analytics & Session Replay data handling and offline support (iOS)](/ios/pnddocs/offline-support-ios.md)
 
 
 Visit the [Mobile Resource Center](https://support.pendo.io/hc/en-us/categories/23324531103771-Mobile-implementation) For additional documentation.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For integration using signed metadata see: [JWT integration instructions](https:
 - [Configuring CNAME Hostnames](https://support.pendo.io/hc/en-us/articles/360047607631-Configure-CNAME-for-Pendo-Mobile)
 - [Work with dynamic content in your mobile app](https://support.pendo.io/hc/en-us/articles/24836902488219-Work-with-dynamic-content-in-your-mobile-app)
 - [Mobile offline support analytics](https://support.pendo.io/hc/en-us/articles/360043016412-Mobile-offline-support-for-analytics)
-- [How the iOS SDK handles analytics & Session Replay data offline (developer reference)](/ios/pnddocs/offline-support-ios.md)
+- [iOS analytics & Session Replay: data handling and offline behavior (developer reference)](/ios/pnddocs/offline-support-ios.md)
 
 
 Visit the [Mobile Resource Center](https://support.pendo.io/hc/en-us/categories/23324531103771-Mobile-implementation) For additional documentation.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For integration using signed metadata see: [JWT integration instructions](https:
 - [Configuring CNAME Hostnames](https://support.pendo.io/hc/en-us/articles/360047607631-Configure-CNAME-for-Pendo-Mobile)
 - [Work with dynamic content in your mobile app](https://support.pendo.io/hc/en-us/articles/24836902488219-Work-with-dynamic-content-in-your-mobile-app)
 - [Mobile offline support analytics](https://support.pendo.io/hc/en-us/articles/360043016412-Mobile-offline-support-for-analytics)
-- [Analytics & Session Replay data handling and offline support (iOS)](/ios/pnddocs/offline-support-ios.md)
+- [How the iOS SDK handles analytics & Session Replay data offline (developer reference)](/ios/pnddocs/offline-support-ios.md)
 
 
 Visit the [Mobile Resource Center](https://support.pendo.io/hc/en-us/categories/23324531103771-Mobile-implementation) For additional documentation.

--- a/ios/pnddocs/offline-support-ios.md
+++ b/ios/pnddocs/offline-support-ios.md
@@ -1,0 +1,233 @@
+# Analytics & Session Replay — Data Handling and Offline Support (iOS)
+
+This document describes how the Pendo iOS SDK handles the two data streams it produces
+— **analytics** and **Session Replay** — from the moment data is captured on the device
+until it reaches the Pendo backend. Offline behavior is part of this story, not a
+separate mode: the same buffering and persistence that let the SDK batch and retry
+uploads are also what let it survive periods without connectivity. We describe the full
+pipeline first, then call out what specifically happens while offline.
+
+We start with **analytics**, then cover **Session Replay**.
+
+> ### ⚠️ Version scope
+> **This document is accurate up to and including SDK 3.14.** The on-device
+> data-handling model is scheduled to change after 3.14 — a later revision of this
+> document will describe the new behavior. If you are on a version newer than 3.14,
+> verify against the release notes for that version.
+
+> ### Notes
+> - iOS-specific. Storage and transport policy are enforced in the native layer, so
+>   React Native, Flutter, Xamarin, and MAUI apps inherit this behavior (see
+>   [Cross-platform](#cross-platform)).
+> - The parameters below are set by Pendo backend configuration. Defaults are listed;
+>   values can be adjusted per subscription on request.
+
+## Contents
+
+- [Analytics](#analytics)
+  - [How analytics data is handled](#how-analytics-data-is-handled)
+  - [Analytics offline behavior](#analytics-offline-behavior)
+- [Session Replay](#session-replay)
+  - [How Session Replay data is handled](#how-session-replay-data-is-handled)
+  - [Session Replay offline behavior](#session-replay-offline-behavior)
+- [Offline signals](#offline-signals)
+- [Configuration reference](#configuration-reference)
+- [Cross-platform](#cross-platform)
+
+---
+
+## Analytics
+
+### How analytics data is handled
+
+Analytics events (screen views, clicks, track events, guide events, session lifecycle,
+etc.) are not uploaded one-by-one as they occur. They are collected on the device,
+persisted to durable on-device storage, batched, and uploaded together. Persisting
+before sending is what lets the SDK batch efficiently and survive periods without
+connectivity.
+
+```
+event → in-memory queue → persistent on-device buffer → (flush trigger + online) → backend
+                                     │
+                              removed only after the backend confirms receipt
+```
+
+- Events first collect in a small in-memory queue, which moves them into the persistent
+  buffer in small groups (**default: every 2 events**, or immediately for an *urgent*
+  event).
+- The persistent buffer holds events until a **flush trigger** fires. When the device is
+  online, the batch is uploaded and removed only after the backend confirms receipt; if
+  the upload fails, the events stay on device.
+
+**Flush triggers & limits** — these govern how often data is uploaded and how much may
+accumulate. All are backend-configurable per subscription:
+
+| Parameter | What it controls | Default | Backend key | Max |
+|---|---|---|---|---|
+| Batch size | Upload after this many events | 20 events\* | `bufferQueueSize` | 1000 |
+| Time interval | Upload at least this often | 30 s | `bufferDuration` | 300 s |
+| Buffer cap | Max on-device accumulation | 10 MB | `maxStorageSizeMB` | 500 MB |
+| Urgent events | Events that force an immediate upload | see below | `immediateEvents` | — |
+
+\* The SDK's built-in fallback is 20 events; production backend configuration commonly
+sets this to 10.
+
+**Urgent events** upload immediately, bypassing the batch-size and time triggers. By
+default: `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed`. The list
+is backend-configurable via `immediateEvents`.
+
+**On-device consumption:** disk is bounded by the buffer cap (default 10 MB); memory is
+just the small in-memory queue.
+
+### Analytics offline behavior
+
+Because events are persisted before they're sent, losing connectivity changes only one
+thing: uploads can't complete, so events accumulate in the on-device buffer instead of
+being removed.
+
+- **Accumulation cap.** The buffer is capped (default 10 MB, backend-configurable via
+  `maxStorageSizeMB`, up to 500 MB). If accumulation exceeds the cap, the SDK discards
+  the **oldest** events first (FIFO), trimming back down to 80% of the cap and keeping
+  the newest data. This trimming happens only while offline or while retrying after a
+  failed upload — never during healthy online operation.
+- **Reconnect.** When connectivity returns, the SDK uploads everything currently in its
+  buffer in a single request — it does **not** drip the backlog out in small batches
+  (subject to the buffer cap).
+- **Retry backoff.** After a failed upload the SDK waits before retrying, starting at
+  **1 s** and **doubling** on each failure up to a **60 s** cap. The delay resets on the
+  next successful upload or when connectivity is restored.
+- **Crash / relaunch recovery.** Events still on device from a previous session are
+  re-loaded and uploaded on the next SDK launch, so data survives an offline period
+  followed by an app kill or crash.
+- **Back-dated session end.** If a session ends because the app was backgrounded past
+  the inactivity timeout (default 30 min), the SDK stamps the session-end events with
+  the time the app was actually backgrounded — not the time it was next launched — so
+  session duration stays accurate. (This applies to the background-timeout path only;
+  it is not reconstructed after a hard crash.)
+
+---
+
+## Session Replay
+
+### How Session Replay data is handled
+
+Session Replay captures the on-screen view hierarchy as a stream of snapshot payloads.
+Each payload is wrapped in an envelope, encoded, and — following the same
+persist-before-send model as analytics — written to a local on-device database before
+any upload (this is called **store-then-forward**).
+
+```
+capture snapshot → envelope → encode → persist to on-device DB → upload in batches
+                                             │                          │
+                                             │        success → payload removed
+                                             │        offline / blocked → payload kept
+                                             ▼
+                                  drained by a flush loop when uploads are allowed
+```
+
+- A payload is removed only after it's successfully uploaded; if it can't be sent yet
+  (offline, or blocked by transport policy), it stays for a later flush.
+- Uploads happen in **batches**, paced to the connection so they don't saturate it: on
+  **WiFi, 10 payloads every 100 ms**; on **cellular, 3 payloads every 500 ms**.
+- **Recording size roll.** A single recording is limited to **100 MiB** of encoded data
+  (`recordingSizeLimit`). When a recording reaches that size, the SDK closes it and
+  starts a new recording segment (a new recording ID). This keeps any one recording
+  bounded rather than growing without limit during long sessions.
+- **Inactivity cutoff.** If the app stays in the background for **30 minutes**
+  (`inactivityDuration`), or loses internet, the current recording is finalized.
+
+**Transport policy** (`networkTransportMode`) controls whether replay data may be
+uploaded over a metered (e.g., cellular) connection. Recording is never affected — only
+when the already-recorded data is uploaded.
+
+| Mode | Behavior |
+|---|---|
+| `wifiAndCellular` (default) | Upload over any connection with internet |
+| `wifiOnly` | Hold data on device over metered connections; upload once on WiFi / unmetered |
+
+**On-device consumption:** disk is bounded by the offline storage cap (default
+250 MiB). All Session Replay sizes use MiB (1024² bytes).
+
+### Session Replay offline behavior
+
+Store-then-forward means an offline period is handled by simply letting persisted
+payloads accumulate in the local database until they can be uploaded, with two
+guardrails that protect device storage:
+
+- **SR storage cap + pause/resume.** The on-device SR store has a cap (default
+  **250 MiB**, backend-configurable via `offlineStorageLimit`). When the store fills to
+  the cap, the SDK **stops recording** so it won't consume more space. It **resumes
+  recording** only once enough buffered data has uploaded to bring the store back below
+  **80%** of the cap. The 100% → 80% gap is deliberate: it prevents recording from
+  rapidly stopping and starting right at the limit.
+- **Device free-space guard.** Independently of the SR cap, if the device's own free
+  storage falls below **300 MiB**, the SDK pauses recording to avoid filling up the
+  user's device.
+- **Retry then discard.** A queued payload that repeatedly times out on upload is
+  retried up to **3 times**, then dropped so it can't block the queue indefinitely.
+- **Recovery.** Anything still in the local database is uploaded on the next launch, so
+  recorded data survives an app kill or crash.
+
+---
+
+## Offline signals
+
+The SDK reports when data was collected offline, or when a storage limit was hit, so
+this is visible on the backend. There are two mechanisms.
+
+### 1. Session Replay envelope fields
+
+Each SR payload carries two flags:
+
+| JSON key | Meaning |
+|---|---|
+| `isOfflineMode` | `true` if the device had no internet when this data was captured. |
+| `isOfflineLimitReached` | `true` on the single payload recorded right as the SR storage cap was hit. Not set on any other payload. |
+
+### 2. Analytics events
+
+The SDK automatically emits these analytics events (they appear alongside your other
+Pendo analytics):
+
+| Event | Emitted when |
+|---|---|
+| `AppOffline` | The device loses internet during an active Session Replay session. |
+| `AppOnline` | The device regains internet — only after a matching `AppOffline`. |
+| `AppOfflineLimitReached` | The SR storage cap (default 250 MiB) is reached. At most once per session. |
+
+`AppOffline` / `AppOnline` track internet loss/restore only — not WiFi ↔ cellular
+switches. The 300 MiB device free-space guard does **not** emit
+`AppOfflineLimitReached`.
+
+---
+
+## Configuration reference
+
+| Area | Parameter (backend key) | Configurable? | Default | Notes |
+|---|---|---|---|---|
+| Analytics | Batch size (`bufferQueueSize`) | Backend | 20 events | Up to 1000; production commonly 10 |
+| Analytics | Time interval (`bufferDuration`) | Backend | 30 s | Up to 300 s |
+| Analytics | Buffer cap (`maxStorageSizeMB`) | Backend | 10 MB | Up to 500 MB |
+| Analytics | Urgent events (`immediateEvents`) | Backend | `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed` | Force immediate upload |
+| Analytics | Overflow trim target | Fixed | 80% of cap | Oldest-first; offline/backoff only |
+| Analytics | Retry backoff | Fixed | 1 s → ×2 → 60 s | Reset on success/reconnect |
+| Analytics | Session timeout | Fixed | 30 min | Back-dates session end |
+| Session Replay | Offline storage cap (`offlineStorageLimit`) | Backend | 250 MiB | Wire value in **bytes** |
+| Session Replay | Resume threshold | Fixed | 80% of cap | Pairs with 100% pause |
+| Session Replay | Device free-space guard | Fixed | 300 MiB | Pauses recording |
+| Session Replay | Recording size roll (`recordingSizeLimit`) | Backend | 100 MiB | Starts a new recording ID |
+| Session Replay | Inactivity cutoff (`inactivityDuration`) | Backend | 30 min | Wire value in **ms** |
+| Session Replay | Transport policy (`networkTransportMode`) | Backend | `wifiAndCellular` | `wifiAndCellular` \| `wifiOnly` |
+| Session Replay | WiFi upload pacing | Fixed | 10 / 100 ms | Batch size / interval |
+| Session Replay | Cellular upload pacing | Fixed | 3 / 500 ms | Batch size / interval |
+| Session Replay | Queued-payload retries | Fixed | 3 | Then discarded |
+
+---
+
+## Cross-platform
+
+Offline **storage** and **transport policy** are enforced in the native iOS layer.
+Session Replay data for React Native, Flutter, Xamarin, and MAUI flows through the same
+native handler, so those platforms inherit this behavior automatically. Correspondingly,
+the storage/transport policy keys (`offlineStorageLimit`, `networkTransportMode`) are
+native-only and are not forwarded across the cross-platform bridges.

--- a/ios/pnddocs/offline-support-ios.md
+++ b/ios/pnddocs/offline-support-ios.md
@@ -10,10 +10,11 @@ pipeline first, then call out what specifically happens while offline.
 We start with **analytics**, then cover **Session Replay**.
 
 > ### ⚠️ Version scope
-> **This document is accurate up to and including SDK 3.14.** The on-device
-> data-handling model is scheduled to change after 3.14 — a later revision of this
-> document will describe the new behavior. If you are on a version newer than 3.14,
-> verify against the release notes for that version.
+> The **analytics** data-handling described here is accurate **up to SDK 3.14**. The
+> analytics on-device data-handling model is being **rewritten in 3.14**, so on 3.14 and
+> later the analytics buffering/persistence behavior differs — verify against the release
+> notes for that version. The **Session Replay** behavior in this document is not affected
+> by that rewrite.
 
 > ### Notes
 > - iOS-specific. Storage and transport policy are enforced in the native layer, so

--- a/ios/pnddocs/offline-support-ios.md
+++ b/ios/pnddocs/offline-support-ios.md
@@ -42,8 +42,8 @@ event  →  in-memory queue  →  on-device storage  →  upload to backend
 ```
 
 1. Each new event goes into a small in-memory queue.
-2. From the queue, events are moved into the persistent on-device buffer. The buffer is
-   the part saved to storage, so nothing is lost if the app closes.
+2. From the queue, events are moved into the persistent on-device buffer. Once in the buffer,
+   events are saved to storage and survive the app closing.
 3. When a **flush trigger** fires (see below) and the device has a connection, the buffered
    events are uploaded. They are deleted from the buffer only after the backend confirms it
    received them; if the upload fails, they stay in the buffer and are retried later.
@@ -56,12 +56,14 @@ event  →  in-memory queue  →  on-device storage  →  upload to backend
 | Time since last upload | 30 s | `bufferDuration` | 300 s |
 | An "urgent" event occurs | immediate | `immediateEvents` | — |
 
-The **Default** values can be changed by Pendo backend configuration per subscription,
-but only up to the **Hard limit** — the backend cannot go beyond those ceilings (they are
-fixed in the SDK). In practice, backend configuration commonly sets the event count to 10.
+The **Default** column is the value built into the SDK. Pendo backend configuration can
+override it per subscription, but only up to the **Hard limit** — the backend cannot go
+beyond those ceilings (they are fixed in the SDK). For example, the SDK's built-in event
+count is 20, while the backend commonly overrides it to 10.
 
-**Urgent events** are uploaded immediately, skipping the count and time triggers. Default:
-`AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed`.
+**Urgent events** trigger an immediate upload, skipping the count and time triggers. This
+flushes **everything currently buffered**, not just the urgent event itself. Default urgent
+events: `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed`.
 
 **Rough event size** — varies a lot by app and screen complexity, so treat these as
 estimates, not fixed values. In memory (uncompressed), click and screen-change events are

--- a/ios/pnddocs/offline-support-ios.md
+++ b/ios/pnddocs/offline-support-ios.md
@@ -1,27 +1,19 @@
 # Analytics & Session Replay — Data Handling and Offline Support (iOS)
 
-This document describes how the Pendo iOS SDK handles the two data streams it produces
-— **analytics** and **Session Replay** — from the moment data is captured on the device
-until it reaches the Pendo backend. Offline behavior is part of this story, not a
-separate mode: the same buffering and persistence that let the SDK batch and retry
-uploads are also what let it survive periods without connectivity. We describe the full
-pipeline first, then call out what specifically happens while offline.
-
-We start with **analytics**, then cover **Session Replay**.
+This document explains how the Pendo iOS SDK collects, stores, and uploads its two data
+streams — **analytics** and **Session Replay** — and how each behaves when the device is
+offline.
 
 > ### ⚠️ Version scope
-> The **analytics** data-handling described here is accurate **up to SDK 3.14**. The
-> analytics on-device data-handling model is being **rewritten in 3.14**, so on 3.14 and
-> later the analytics buffering/persistence behavior differs — verify against the release
-> notes for that version. The **Session Replay** behavior in this document is not affected
-> by that rewrite.
+> The **analytics** behavior described here is accurate up to SDK 3.14; it is being
+> rewritten in 3.14.
 
 > ### Notes
-> - iOS-specific. Storage and transport policy are enforced in the native layer, so
->   React Native, Flutter, Xamarin, and MAUI apps inherit this behavior (see
->   [Cross-platform](#cross-platform)).
-> - The parameters below are set by Pendo backend configuration. Defaults are listed;
->   values can be adjusted per subscription on request.
+> - iOS-specific. Storage and transport rules run in the native layer, so React Native,
+>   Flutter, Xamarin, and MAUI apps inherit this behavior (see [Cross-platform](#cross-platform)).
+> - Most values below have a default set by Pendo and can be changed through backend
+>   configuration per subscription, **up to a fixed maximum** that the backend cannot
+>   exceed.
 
 ## Contents
 
@@ -42,69 +34,61 @@ We start with **analytics**, then cover **Session Replay**.
 ### How analytics data is handled
 
 Analytics events (screen views, clicks, track events, guide events, session lifecycle,
-etc.) are not uploaded one-by-one as they occur. They are collected on the device,
-persisted to durable on-device storage, batched, and uploaded together. Persisting
-before sending is what lets the SDK batch efficiently and survive periods without
-connectivity.
+etc.) are not uploaded one at a time. The SDK collects them, saves them to on-device
+storage, and uploads them in batches:
 
 ```
-event → in-memory queue → persistent on-device buffer → (flush trigger + online) → backend
-                                     │
-                              removed only after the backend confirms receipt
+event  →  in-memory queue  →  on-device storage  →  upload to backend
 ```
 
-- Events first collect in a small in-memory queue, which moves them into the persistent
-  buffer in small groups (**default: every 2 events**, or immediately for an *urgent*
-  event).
-- The persistent buffer holds events until a **flush trigger** fires. When the device is
-  online, the batch is uploaded and removed only after the backend confirms receipt; if
-  the upload fails, the events stay on device.
+1. Each new event goes into a small in-memory queue.
+2. From the queue, events are moved into the persistent on-device buffer. The buffer is
+   the part saved to storage, so nothing is lost if the app closes.
+3. When a **flush trigger** fires (see below) and the device has a connection, the buffered
+   events are uploaded. They are deleted from the buffer only after the backend confirms it
+   received them; if the upload fails, they stay in the buffer and are retried later.
 
-**Flush triggers & limits** — these govern how often data is uploaded and how much may
-accumulate. All are backend-configurable per subscription:
+**Flush triggers** — the SDK uploads whenever any one of these is reached:
 
-| Parameter | What it controls | Default | Backend key | Max |
-|---|---|---|---|---|
-| Batch size | Upload after this many events | 20 events\* | `bufferQueueSize` | 1000 |
-| Time interval | Upload at least this often | 30 s | `bufferDuration` | 300 s |
-| Buffer cap | Max on-device accumulation | 10 MB | `maxStorageSizeMB` | 500 MB |
-| Urgent events | Events that force an immediate upload | see below | `immediateEvents` | — |
+| What triggers an upload | Default | Backend key | Hard limit |
+|---|---|---|---|
+| Number of queued events | 20 events | `bufferQueueSize` | 1000 |
+| Time since last upload | 30 s | `bufferDuration` | 300 s |
+| An "urgent" event occurs | immediate | `immediateEvents` | — |
 
-\* The SDK's built-in fallback is 20 events; production backend configuration commonly
-sets this to 10.
+The **Default** values can be changed by Pendo backend configuration per subscription,
+but only up to the **Hard limit** — the backend cannot go beyond those ceilings (they are
+fixed in the SDK). In practice, backend configuration commonly sets the event count to 10.
 
-**Urgent events** upload immediately, bypassing the batch-size and time triggers. By
-default: `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed`. The list
-is backend-configurable via `immediateEvents`.
+**Urgent events** are uploaded immediately, skipping the count and time triggers. Default:
+`AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed`.
 
-**On-device consumption:** disk is bounded by the buffer cap (default 10 MB); memory is
-just the small in-memory queue.
+**Rough event size** — varies a lot by app and screen complexity, so treat these as
+estimates, not fixed values. In memory (uncompressed), click and screen-change events are
+in the same ballpark, roughly **2–9 KB each** (either can be larger depending on the
+screen); lifecycle events (e.g. session start) are ~0.3 KB. On the network each event is
+gzipped as part of the batch, roughly **4–6× smaller** — about **1–1.5 KB** for a typical
+click or screen-change event.
 
 ### Analytics offline behavior
 
-Because events are persisted before they're sent, losing connectivity changes only one
-thing: uploads can't complete, so events accumulate in the on-device buffer instead of
-being removed.
+While offline, uploads simply fail, so events keep accumulating in on-device storage until
+the connection returns.
 
-- **Accumulation cap.** The buffer is capped (default 10 MB, backend-configurable via
-  `maxStorageSizeMB`, up to 500 MB). If accumulation exceeds the cap, the SDK discards
-  the **oldest** events first (FIFO), trimming back down to 80% of the cap and keeping
-  the newest data. This trimming happens only while offline or while retrying after a
-  failed upload — never during healthy online operation.
-- **Reconnect.** When connectivity returns, the SDK uploads everything currently in its
-  buffer in a single request — it does **not** drip the backlog out in small batches
-  (subject to the buffer cap).
-- **Retry backoff.** After a failed upload the SDK waits before retrying, starting at
-  **1 s** and **doubling** on each failure up to a **60 s** cap. The delay resets on the
-  next successful upload or when connectivity is restored.
-- **Crash / relaunch recovery.** Events still on device from a previous session are
-  re-loaded and uploaded on the next SDK launch, so data survives an offline period
-  followed by an app kill or crash.
-- **Back-dated session end.** If a session ends because the app was backgrounded past
-  the inactivity timeout (default 30 min), the SDK stamps the session-end events with
-  the time the app was actually backgrounded — not the time it was next launched — so
-  session duration stays accurate. (This applies to the background-timeout path only;
-  it is not reconstructed after a hard crash.)
+- **Storage cap.** The buffer is capped (default 10 MB, up to 500 MB). When it reaches the
+  cap, the SDK deletes the **oldest** events until the buffer is back down to 80% of the
+  cap, then keeps collecting. So the newest events are always kept.
+- **Reconnect.** When the connection returns, the SDK uploads everything it has stored in
+  one request — it does not trickle it out in small batches.
+- **Retry backoff.** After a failed upload the SDK waits before trying again: 1 s, then
+  doubling each time (2 s, 4 s, …) up to a maximum of 60 s. The wait resets after a
+  successful upload or when the connection returns.
+- **Crash / relaunch recovery.** Events saved on the device from a previous run are
+  uploaded the next time the SDK starts, so nothing is lost across an app close or crash.
+- **Back-dated session end.** Pendo ends a session if the app is sent to the background and
+  not reopened within the inactivity timeout (default 30 min). The session-end event is
+  timestamped with the moment the app was actually backgrounded — not the moment Pendo
+  later noticed the timeout — so the reported session length stays correct. 
 
 ---
 
@@ -112,123 +96,104 @@ being removed.
 
 ### How Session Replay data is handled
 
-Session Replay captures the on-screen view hierarchy as a stream of snapshot payloads.
-Each payload is wrapped in an envelope, encoded, and — following the same
-persist-before-send model as analytics — written to a local on-device database before
-any upload (this is called **store-then-forward**).
+Session Replay records the on-screen view hierarchy as a series of snapshots. Each
+snapshot is packaged into an **envelope**, encoded with Pendo's **JZB** format
+(gzip-compressed JSON), saved to a local database, and then uploaded. Saving before
+uploading is called **store-then-forward**.
 
 ```
-capture snapshot → envelope → encode → persist to on-device DB → upload in batches
-                                             │                          │
-                                             │        success → payload removed
-                                             │        offline / blocked → payload kept
-                                             ▼
-                                  drained by a flush loop when uploads are allowed
+snapshot  →  envelope (JZB-encoded)  →  saved to on-device database  →  upload
 ```
 
-- A payload is removed only after it's successfully uploaded; if it can't be sent yet
-  (offline, or blocked by transport policy), it stays for a later flush.
-- Uploads happen in **batches**, paced to the connection so they don't saturate it: on
-  **WiFi, 10 payloads every 100 ms**; on **cellular, 3 payloads every 500 ms**.
-- **Recording size roll.** A single recording is limited to **100 MiB** of encoded data
-  (`recordingSizeLimit`). When a recording reaches that size, the SDK closes it and
-  starts a new recording segment (a new recording ID). This keeps any one recording
-  bounded rather than growing without limit during long sessions.
-- **Inactivity cutoff.** If the app stays in the background for **30 minutes**
-  (`inactivityDuration`), or loses internet, the current recording is finalized.
+- A saved item is deleted only after it uploads successfully. If it can't be sent yet
+  (offline, or blocked by the transport policy below), it stays in the database and is
+  retried later.
+- To avoid flooding the network, the SDK uploads saved items in small groups sized to the
+  connection: up to **10 at a time on WiFi**, **3 at a time on cellular**.
+- **Image compression.** Images are the largest part of a snapshot, so before they're
+  embedded the SDK renders each at **0.8 scale** and encodes it as **JPEG at 10% quality**.
+  Each encoded image is also **cached per image**, so an image that appears in multiple
+  snapshots is only rendered and encoded once. The whole envelope is then gzipped (JZB) on
+  top of that. This keeps both CPU/memory and upload size down — often shrinking each image
+  to just a few percent of its original size (roughly 10–20× smaller).
 
-**Transport policy** (`networkTransportMode`) controls whether replay data may be
-uploaded over a metered (e.g., cellular) connection. Recording is never affected — only
-when the already-recorded data is uploaded.
+**Transport policy** (`networkTransportMode`) controls whether replay data may upload over
+a metered (e.g., cellular) connection. Recording itself is never affected — only *when* the
+data is uploaded.
 
 | Mode | Behavior |
 |---|---|
-| `wifiAndCellular` (default) | Upload over any connection with internet |
-| `wifiOnly` | Hold data on device over metered connections; upload once on WiFi / unmetered |
+| `wifiAndCellular` (default) | Upload over any connection |
+| `wifiOnly` | Keep data on the device while on cellular; upload once on WiFi |
 
-**On-device consumption:** disk is bounded by the offline storage cap (default
-250 MiB). All Session Replay sizes use MiB (1024² bytes).
+**On-device storage:** capped at 250 MB by default (see below).
 
 ### Session Replay offline behavior
 
-Store-then-forward means an offline period is handled by simply letting persisted
-payloads accumulate in the local database until they can be uploaded, with two
-guardrails that protect device storage:
+While offline, recorded data stays in the local database and is uploaded when the
+connection returns. Two guardrails protect the device:
 
-- **SR storage cap + pause/resume.** The on-device SR store has a cap (default
-  **250 MiB**, backend-configurable via `offlineStorageLimit`). When the store fills to
-  the cap, the SDK **stops recording** so it won't consume more space. It **resumes
-  recording** only once enough buffered data has uploaded to bring the store back below
-  **80%** of the cap. The 100% → 80% gap is deliberate: it prevents recording from
-  rapidly stopping and starting right at the limit.
-- **Device free-space guard.** Independently of the SR cap, if the device's own free
-  storage falls below **300 MiB**, the SDK pauses recording to avoid filling up the
-  user's device.
-- **Retry then discard.** A queued payload that repeatedly times out on upload is
-  retried up to **3 times**, then dropped so it can't block the queue indefinitely.
-- **Recovery.** Anything still in the local database is uploaded on the next launch, so
-  recorded data survives an app kill or crash.
+- **Storage cap (pause / resume).** The database is capped (default 250 MB,
+  backend-configurable via `offlineStorageLimit`). When it fills to the cap, the SDK
+  **stops recording** so it won't use more space. Once uploads bring it back below **80%**
+  of the cap, recording **resumes**. The gap between stopping at 100% and resuming at 80%
+  keeps recording from flickering on and off right at the limit.
+- **Low device storage.** Separately, if the whole device drops below **300 MB** of free
+  space, the SDK pauses recording so it doesn't fill up the user's phone.
+- **Retry then discard.** If uploading a saved item keeps timing out, the SDK retries up
+  to 3 times, then discards it so it can't block everything behind it.
+- **Recovery.** Anything left in the database is uploaded the next time the app launches,
+  so recordings survive an app close or crash.
 
 ---
 
 ## Offline signals
 
-The SDK reports when data was collected offline, or when a storage limit was hit, so
-this is visible on the backend. There are two mechanisms.
+The SDK reports when data was collected offline, or when the storage limit was hit, in two
+ways.
 
 ### 1. Session Replay envelope fields
 
-Each SR payload carries two flags:
+Each Session Replay item carries two flags:
 
 | JSON key | Meaning |
 |---|---|
 | `isOfflineMode` | `true` if the device had no internet when this data was captured. |
-| `isOfflineLimitReached` | `true` on the single payload recorded right as the SR storage cap was hit. Not set on any other payload. |
+| `isOfflineLimitReached` | `true` on the single item recorded right as the storage cap was hit. Not set on any other item. |
 
 ### 2. Analytics events
 
-The SDK automatically emits these analytics events (they appear alongside your other
-Pendo analytics):
+The SDK automatically emits these analytics events (they appear alongside your other Pendo
+analytics):
 
 | Event | Emitted when |
 |---|---|
 | `AppOffline` | The device loses internet during an active Session Replay session. |
 | `AppOnline` | The device regains internet — only after a matching `AppOffline`. |
-| `AppOfflineLimitReached` | The SR storage cap (default 250 MiB) is reached. At most once per session. |
+| `AppOfflineLimitReached` | The Session Replay storage cap (default 250 MB) is reached. At most once per session. |
 
-`AppOffline` / `AppOnline` track internet loss/restore only — not WiFi ↔ cellular
-switches. The 300 MiB device free-space guard does **not** emit
-`AppOfflineLimitReached`.
+`AppOffline` / `AppOnline` track internet loss/restore only — not WiFi ↔ cellular switches.
+The 300 MB low-device-storage pause does **not** emit `AppOfflineLimitReached`.
 
 ---
 
 ## Configuration reference
 
-| Area | Parameter (backend key) | Configurable? | Default | Notes |
+| Area | Setting (backend key) | Changeable by backend? | Default | Notes |
 |---|---|---|---|---|
-| Analytics | Batch size (`bufferQueueSize`) | Backend | 20 events | Up to 1000; production commonly 10 |
-| Analytics | Time interval (`bufferDuration`) | Backend | 30 s | Up to 300 s |
-| Analytics | Buffer cap (`maxStorageSizeMB`) | Backend | 10 MB | Up to 500 MB |
-| Analytics | Urgent events (`immediateEvents`) | Backend | `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed` | Force immediate upload |
-| Analytics | Overflow trim target | Fixed | 80% of cap | Oldest-first; offline/backoff only |
-| Analytics | Retry backoff | Fixed | 1 s → ×2 → 60 s | Reset on success/reconnect |
+| Analytics | Batch size (`bufferQueueSize`) | Yes | 20 events | Max 1000; commonly set to 10 |
+| Analytics | Time interval (`bufferDuration`) | Yes | 30 s | Max 300 s |
+| Analytics | Storage cap (`maxStorageSizeMB`) | Yes | 10 MB | Max 500 MB |
+| Analytics | Urgent events (`immediateEvents`) | Yes | `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed` | Uploaded immediately |
+| Analytics | Overflow behavior | Fixed | Drop oldest, trim to 80% of cap | Offline / retry only |
+| Analytics | Retry backoff | Fixed | 1 s → doubles → 60 s max | Resets on success/reconnect |
 | Analytics | Session timeout | Fixed | 30 min | Back-dates session end |
-| Session Replay | Offline storage cap (`offlineStorageLimit`) | Backend | 250 MiB | Wire value in **bytes** |
-| Session Replay | Resume threshold | Fixed | 80% of cap | Pairs with 100% pause |
-| Session Replay | Device free-space guard | Fixed | 300 MiB | Pauses recording |
-| Session Replay | Recording size roll (`recordingSizeLimit`) | Backend | 100 MiB | Starts a new recording ID |
-| Session Replay | Inactivity cutoff (`inactivityDuration`) | Backend | 30 min | Wire value in **ms** |
-| Session Replay | Transport policy (`networkTransportMode`) | Backend | `wifiAndCellular` | `wifiAndCellular` \| `wifiOnly` |
-| Session Replay | WiFi upload pacing | Fixed | 10 / 100 ms | Batch size / interval |
-| Session Replay | Cellular upload pacing | Fixed | 3 / 500 ms | Batch size / interval |
-| Session Replay | Queued-payload retries | Fixed | 3 | Then discarded |
+| Session Replay | Storage cap (`offlineStorageLimit`) | Yes | 250 MB | Backend value sent in bytes |
+| Session Replay | Resume threshold | Fixed | 80% of cap | Recording pauses at 100% |
+| Session Replay | Low-device-storage pause | Fixed | 300 MB free | Pauses recording |
+| Session Replay | Transport policy (`networkTransportMode`) | Yes | `wifiAndCellular` | `wifiAndCellular` or `wifiOnly` |
+| Session Replay | WiFi upload group size | Fixed | 10 items | Items uploaded per group on WiFi |
+| Session Replay | Cellular upload group size | Fixed | 3 items | Items uploaded per group on cellular |
+| Session Replay | Upload retries | Fixed | 3 | Then discarded |
 
 ---
-
-## Cross-platform
-
-Offline **storage** and **transport policy** are enforced in the native iOS layer.
-Session Replay data for React Native, Flutter, Xamarin, and MAUI flows through the same
-native handler, so those platforms inherit this behavior automatically. Correspondingly,
-the storage/transport policy keys (`offlineStorageLimit`, `networkTransportMode`) are
-native-only and are not forwarded across the cross-platform bridges.

--- a/ios/pnddocs/offline-support-ios.md
+++ b/ios/pnddocs/offline-support-ios.md
@@ -5,8 +5,8 @@ streams — **analytics** and **Session Replay** — and how each behaves when t
 offline.
 
 > ### ⚠️ Version scope
-> The **analytics** behavior described here is accurate up to SDK 3.14; it is being
-> rewritten in 3.14.
+> The **analytics** behavior described here is accurate up to SDK 3.14; the analytics
+> pipeline is being rewritten after 3.14.
 
 > ### Notes
 > - iOS-specific. Storage and transport rules run in the native layer, so React Native,
@@ -187,7 +187,7 @@ The 300 MB low-device-storage pause does **not** emit `AppOfflineLimitReached`.
 | Analytics | Urgent events (`immediateEvents`) | Yes | `AppSessionEnd`, `AppInBackground`, `GuideDismissed`, `GuideSnoozed` | Uploaded immediately |
 | Analytics | Overflow behavior | Fixed | Drop oldest, trim to 80% of cap | Offline / retry only |
 | Analytics | Retry backoff | Fixed | 1 s → doubles → 60 s max | Resets on success/reconnect |
-| Analytics | Session timeout | Fixed | 30 min | Back-dates session end |
+| Analytics | Session timeout | Yes | 30 min | Back-dates session end |
 | Session Replay | Storage cap (`offlineStorageLimit`) | Yes | 250 MB | Backend value sent in bytes |
 | Session Replay | Resume threshold | Fixed | 80% of cap | Recording pauses at 100% |
 | Session Replay | Low-device-storage pause | Fixed | 300 MB free | Pauses recording |


### PR DESCRIPTION
## Summary

- Adds a developer-facing doc (`ios/pnddocs/offline-support-ios.md`) describing how the iOS SDK handles **analytics** and **Session Replay** data end to end — buffering, on-device persistence, batching, flush triggers, and retry — and how each stream behaves **offline** (accumulation caps, FIFO trim, pause/resume hysteresis, device free-space guard, crash/relaunch recovery).
- Documents the **offline signals**: SR envelope fields (`isOfflineMode`, `isOfflineLimitReached`) and analytics events (`AppOffline`, `AppOnline`, `AppOfflineLimitReached`).
- Includes a full **configuration reference** (backend-configurable vs fixed, defaults, bounds, backend keys) and a **cross-platform** note (storage + transport policy enforced natively; RN/Flutter/Xamarin/MAUI inherit).
- Links the doc from the README under **Additional resources**.
- Scoped/verified against the current shipping SDK (accurate up to and including **3.14**; a later revision will cover the post-3.14 changes).

## Test plan

- [ ] Verify the README link resolves to the new doc.
- [ ] Review technical accuracy of the documented defaults/behavior against 3.14.

Made with [Cursor](https://cursor.com)