### PR TITLE
APP-163829 Add Compose Multiplatform integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The Pendo Mobile SDK is a codeless library that collects analytics retroactively
 [Android](/android/pnddocs/native-android.md) | 
 [iOS](/ios/pnddocs/native-ios.md)
 - Kotlin Multiplatform:
-[Native UI](/other/kotlin-multiplatform-native-ui.md)
+[Native UI](/other/kotlin-multiplatform-native-ui.md) |
+[Compose Multiplatform](/other/compose-multiplatform.md)
 - React Native:
     - Using React Navigation:
     [Android](/android/pnddocs/rn-android.md) | 
@@ -55,6 +56,7 @@ For integration using signed metadata see: [JWT integration instructions](https:
 - [Xamarin Forms](/api-documentation/xamarin-forms-apis.md)
 - [MAUI](/api-documentation/xamarin-maui-apis.md)
 - [Flutter](/api-documentation/flutter-apis.md)
+- [Compose Multiplatform](/api-documentation/compose-multiplatform-apis.md)
 
 
 ## Additional resources 

--- a/api-documentation/compose-multiplatform-apis.md
+++ b/api-documentation/compose-multiplatform-apis.md
@@ -1,0 +1,511 @@
+# Compose Multiplatform public developer API documentation
+
+> [!IMPORTANT]
+> Call `Pendo.setup()` before `Pendo.startSession()`. Except for `setDebugMode()` and `endSession()`, call the remaining APIs after both `setup()` and `startSession()`. Calls that require an active session are ignored when Pendo is inactive. `Pendo.setDebugMode()` may be called before setup.
+
+Core APIs and modifiers are available from `com.pendo.cmp`. Navigation adapters are available from `com.pendo.cmp.nav`.
+
+## Pendo APIs
+
+- [`setup`](#setup)
+- [`startSession`](#startsession)
+- [`endSession`](#endsession)
+- [`track`](#track)
+- [`setVisitorData`](#setvisitordata)
+- [`setAccountData`](#setaccountdata)
+- [`setDebugMode`](#setdebugmode)
+- [`getDeviceId`](#getdeviceid)
+- [`pauseGuides`](#pauseguides)
+- [`resumeGuides`](#resumeguides)
+- [`dismissVisibleGuides`](#dismissvisibleguides)
+- [`initWithUrl`](#initwithurl)
+- [`screenContentChanged`](#screencontentchanged)
+
+## Configuration APIs
+
+- [`PendoOptions`](#pendooptions)
+- [`PendoInitCallback`](#pendoinitcallback)
+
+## Compose tracking APIs
+
+- [`PendoTracker`](#pendotracker)
+- [`PendoNavigator`](#pendonavigator)
+- [`PendoNav2`](#pendonav2)
+- [`PendoCircuit`](#pendocircuit)
+- [`pendoTag`](#pendotag)
+- [`pendoScreenId`](#pendoscreenid)
+- [`pendoStateModifier`](#pendostatemodifier)
+- [`applyPendoSRPrivacy`](#applypendosrprivacy)
+- [`clearPendoSRPrivacy`](#clearpendosrprivacy)
+- [`PrivacyAction`](#privacyaction)
+
+## Pendo APIs
+
+### `setup`
+
+```kotlin
+fun setup(
+    appKey: String,
+    options: PendoOptions? = null,
+    callback: PendoInitCallback? = null,
+)
+```
+
+Establishes the connection to Pendo. Call this once, as early as possible during application startup.
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `appKey` | `String` | The app key shown in the Pendo UI under the application’s settings. |
+| `options` | `PendoOptions?` | Optional SDK configuration. |
+| `callback` | `PendoInitCallback?` | Optional initialization callback. |
+
+```kotlin
+Pendo.setup(
+    appKey = "YOUR_APP_KEY",
+    options = PendoOptions(environmentName = "production"),
+    callback = object : PendoInitCallback {
+        override fun onInitComplete() {
+            // Pendo initialization completed
+        }
+
+        override fun onInitFailed() {
+            // Pendo initialization failed
+        }
+    },
+)
+```
+
+### `startSession`
+
+```kotlin
+fun startSession(
+    visitorId: String?,
+    accountId: String?,
+    visitorData: Map<String, Any>? = null,
+    accountData: Map<String, Any>? = null,
+)
+```
+
+Starts a session with the provided visitor and account information. Starting a session ends any previously active session. Pass `null` for `visitorId` to start an anonymous session.
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `visitorId` | `String?` | Unique visitor ID, or `null` for an anonymous visitor. |
+| `accountId` | `String?` | Unique account ID, or `null`. |
+| `visitorData` | `Map<String, Any>?` | Optional visitor metadata. |
+| `accountData` | `Map<String, Any>?` | Optional account metadata. |
+
+```kotlin
+Pendo.startSession(
+    visitorId = "VISITOR-UNIQUE-ID",
+    accountId = "ACCOUNT-UNIQUE-ID",
+    visitorData = mapOf("country" to "USA"),
+    accountData = mapOf("tier" to "Enterprise"),
+)
+```
+
+### `endSession`
+
+```kotlin
+fun endSession()
+```
+
+Ends the current session and stops collecting analytics. Call this API when the user logs out. Start a new session when another visitor logs in.
+
+```kotlin
+Pendo.endSession()
+```
+
+### `track`
+
+```kotlin
+fun track(
+    event: String,
+    properties: Map<String, Any>? = null,
+)
+```
+
+Sends a Track Event for the active session.
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `event` | `String` | Name describing the event. |
+| `properties` | `Map<String, Any>?` | Optional event properties. Use interoperable values such as strings, numbers, and booleans. |
+
+```kotlin
+Pendo.track(
+    event = "Checkout Completed",
+    properties = mapOf("itemCount" to 3, "total" to 42.50),
+)
+```
+
+### `setVisitorData`
+
+```kotlin
+fun setVisitorData(data: Map<String, Any>)
+```
+
+Updates visitor metadata for the active session.
+
+```kotlin
+Pendo.setVisitorData(
+    mapOf("plan" to "Pro", "isAdmin" to true),
+)
+```
+
+### `setAccountData`
+
+```kotlin
+fun setAccountData(data: Map<String, Any>)
+```
+
+Updates account metadata for the active session.
+
+```kotlin
+Pendo.setAccountData(
+    mapOf("region" to "EMEA", "employeeCount" to 250),
+)
+```
+
+### `setDebugMode`
+
+```kotlin
+fun setDebugMode(enabled: Boolean)
+```
+
+Enables or disables detailed SDK logging. Enable debug mode only during development. This API may be called before `setup()`.
+
+```kotlin
+Pendo.setDebugMode(true)
+```
+
+### `getDeviceId`
+
+```kotlin
+fun getDeviceId(): String
+```
+
+Returns the device identifier used by Pendo. Returns an empty string when Pendo is not active.
+
+```kotlin
+val deviceId = Pendo.getDeviceId()
+```
+
+### `pauseGuides`
+
+```kotlin
+fun pauseGuides(dismissGuides: Boolean = false)
+```
+
+Pauses guide presentation for the active session.
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `dismissGuides` | `Boolean` | When `true`, also dismisses any currently visible guide. |
+
+```kotlin
+Pendo.pauseGuides(dismissGuides = true)
+```
+
+### `resumeGuides`
+
+```kotlin
+fun resumeGuides()
+```
+
+Resumes guide presentation after `pauseGuides()`.
+
+```kotlin
+Pendo.resumeGuides()
+```
+
+### `dismissVisibleGuides`
+
+```kotlin
+fun dismissVisibleGuides()
+```
+
+Dismisses any currently visible guides.
+
+```kotlin
+Pendo.dismissVisibleGuides()
+```
+
+### `initWithUrl`
+
+```kotlin
+fun initWithUrl(url: String)
+```
+
+Processes a Pendo Pairing Mode URL on iOS. Configure Android Pairing Mode in `AndroidManifest.xml` as described in the [Compose Multiplatform integration guide](/other/compose-multiplatform.md#android).
+
+```kotlin
+Pendo.initWithUrl(pairingUrl)
+```
+
+When called from Swift, this API is exported as:
+
+```swift
+Pendo.shared.handleDeepLink(url: url.absoluteString)
+```
+
+### `screenContentChanged`
+
+```kotlin
+fun screenContentChanged()
+```
+
+Notifies Pendo that dynamic content changed and requests a new scan of the current screen.
+
+```kotlin
+Pendo.screenContentChanged()
+```
+
+## Configuration APIs
+
+### `PendoOptions`
+
+```kotlin
+data class PendoOptions(
+    val environmentName: String? = null,
+    val disableAnalytics: Boolean = false,
+    val includeAllGuideContent: Boolean = false,
+)
+```
+
+| Property | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `environmentName` | `String?` | `null` | Optional environment name, such as `staging` or `production`. |
+| `disableAnalytics` | `Boolean` | `false` | Disables analytics collection when `true`. |
+| `includeAllGuideContent` | `Boolean` | `false` | Includes all guide content in the initialization model when `true`. |
+
+Pass an instance to `Pendo.setup()`:
+
+```kotlin
+Pendo.setup(
+    appKey = "YOUR_APP_KEY",
+    options = PendoOptions(
+        environmentName = "production",
+        disableAnalytics = false,
+    ),
+)
+```
+
+### `PendoInitCallback`
+
+```kotlin
+interface PendoInitCallback {
+    fun onInitComplete()
+    fun onInitFailed()
+}
+```
+
+Receives SDK initialization results. Both methods are invoked on the main thread.
+
+## Compose tracking APIs
+
+### `PendoTracker`
+
+```kotlin
+@Composable
+fun PendoTracker(
+    navigator: PendoNavigator? = null,
+    content: @Composable () -> Unit,
+)
+```
+
+Wraps shared Compose content for Pendo tracking. Pass a supported navigator to enable automatic screen detection, or omit it when the content does not use a supported navigation library.
+
+```kotlin
+PendoTracker(navigator = PendoNav2(navController)) {
+    NavHost(navController, startDestination = "home") {
+        // Destinations
+    }
+}
+```
+
+`PendoTracker` can be nested when an application has multiple navigation levels.
+
+### `PendoNavigator`
+
+```kotlin
+sealed interface PendoNavigator
+```
+
+Represents a supported navigation adapter for `PendoTracker`. Use `PendoNav2` for Jetpack Compose Navigation 2 or `PendoCircuit` for Slack Circuit.
+
+### `PendoNav2`
+
+```kotlin
+class PendoNav2(
+    val navController: Any,
+) : PendoNavigator
+```
+
+Adapts a Jetpack Compose Navigation 2 `NavController` for `PendoTracker`.
+
+```kotlin
+PendoTracker(navigator = PendoNav2(navController)) {
+    NavHost(navController, startDestination = "home") {
+        // Destinations
+    }
+}
+```
+
+### `PendoCircuit`
+
+```kotlin
+class PendoCircuit(
+    val backStack: Any,
+) : PendoNavigator
+```
+
+Adapts a Slack Circuit `SaveableBackStack` for `PendoTracker`.
+
+```kotlin
+PendoTracker(navigator = PendoCircuit(backStack)) {
+    NavigableCircuitContent(navigator, backStack)
+}
+```
+
+### `pendoTag`
+
+```kotlin
+fun Modifier.pendoTag(
+    tag: String,
+    mergeDescendants: Boolean = false,
+): Modifier
+```
+
+Adds a stable, localization-independent identifier to a Compose element. Tagged elements can be identified in analytics and targeted by guides.
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
+| `tag` | `String` | Unique identifier for the element. |
+| `mergeDescendants` | `Boolean` | Merges descendant semantics into this element when `true`. |
+
+```kotlin
+Button(
+    modifier = Modifier.pendoTag(
+        tag = "checkout_button",
+        mergeDescendants = true,
+    ),
+    onClick = ::checkout,
+) {
+    Text("Checkout")
+}
+```
+
+### `pendoScreenId`
+
+```kotlin
+fun Modifier.pendoScreenId(screenId: String): Modifier
+```
+
+Marks a composable as a distinct screen. Use it for screens such as tabs or state-driven content that do not have their own navigation route.
+
+The screen ID must:
+
+- not be blank
+- contain no more than 100 characters
+- contain only letters, numbers, underscores, hyphens, and periods
+
+```kotlin
+Box(
+    modifier = Modifier.pendoScreenId("ProfileTab"),
+) {
+    ProfileContent()
+}
+```
+
+### `pendoStateModifier`
+
+```kotlin
+fun Modifier.pendoStateModifier(state: DrawerState): Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+fun Modifier.pendoStateModifier(state: SheetState): Modifier
+```
+
+Tracks Material 3 drawer and bottom-sheet visibility for Pendo.
+
+```kotlin
+ModalNavigationDrawer(
+    drawerState = drawerState,
+    modifier = Modifier.pendoStateModifier(drawerState),
+    drawerContent = {
+        // Drawer content
+    },
+) {
+    // Screen content
+}
+```
+
+```kotlin
+ModalBottomSheet(
+    sheetState = sheetState,
+    modifier = Modifier.pendoStateModifier(sheetState),
+    onDismissRequest = {
+        scope.launch {
+            sheetState.hide()
+        }
+    },
+) {
+    // Sheet content
+}
+```
+
+### `applyPendoSRPrivacy`
+
+```kotlin
+fun Modifier.applyPendoSRPrivacy(
+    action: PrivacyAction,
+): Modifier
+```
+
+Applies a Session Replay privacy action to a composable. Privacy actions cascade to descendants. An ancestor using `PrivacyAction.BLOCK` cannot be overridden by a descendant.
+
+Apply only one Session Replay privacy modifier to an element.
+
+```kotlin
+TextField(
+    modifier = Modifier.applyPendoSRPrivacy(PrivacyAction.MASK),
+    value = value,
+    onValueChange = onValueChange,
+)
+```
+
+### `clearPendoSRPrivacy`
+
+```kotlin
+fun Modifier.clearPendoSRPrivacy(): Modifier
+```
+
+Clears the privacy action on an element so it uses inherited or configured Session Replay behavior.
+
+Use this modifier by itself. Do not chain it after `applyPendoSRPrivacy()` on the same element.
+
+```kotlin
+Text(
+    modifier = Modifier.clearPendoSRPrivacy(),
+    text = "Public content",
+)
+```
+
+### `PrivacyAction`
+
+```kotlin
+enum class PrivacyAction {
+    MASK,
+    UNMASK,
+    BLOCK,
+}
+```
+
+| Value | Description |
+| :--- | :--- |
+| `MASK` | Redacts text. It does not affect images or other non-text content. |
+| `UNMASK` | Reveals non-sensitive text that would otherwise be masked. Password fields remain masked. |
+| `BLOCK` | Replaces the element and its descendants with a placeholder and excludes interactions within its bounds. |
+
+Compose cannot automatically identify email and phone fields as sensitive. Avoid `UNMASK` on those fields, or protect them with password semantics.

--- a/other/compose-multiplatform.md
+++ b/other/compose-multiplatform.md
@@ -1,0 +1,379 @@
+# Compose Multiplatform
+
+> [!IMPORTANT]
+> Use this guide when your Android and iOS applications share UI with Compose Multiplatform. If your KMP project uses platform-native UI, follow the [Kotlin Multiplatform with native UI guide](/other/kotlin-multiplatform-native-ui.md).
+
+> [!NOTE]
+> The following integration instructions are relevant for Pendo CMP SDK `3.14.x`.
+
+> [!IMPORTANT]
+> Requirements:
+> - Kotlin `2.1.0` or higher
+> - Compose Multiplatform `1.8.0` or higher
+> - Supported Compose UI versions up to `1.12`
+> - Pendo iOS SDK `3.14.x` (must match the CMP SDK minor version)
+> - iOS deployment target `13.0` or higher
+> - Android `minSdk 21` or higher
+>
+> Supported navigation libraries:
+> - Jetpack Compose Navigation (Navigation 2)
+> - Slack Circuit `0.20.0` or higher
+
+## Step 1. Add the Pendo CMP SDK
+
+### Add the Pendo repositories
+
+Add the repositories for the CMP SDK and the native Android SDK to `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        // CMP SDK
+        maven {
+            url = uri("https://software.mobile.pendo.io/artifactory/cmp-beta/")
+        }
+
+        // Native Android SDK
+        maven {
+            url = uri("https://software.mobile.pendo.io/artifactory/androidx-release")
+        }
+
+        mavenCentral()
+        google()
+    }
+}
+```
+
+The Pendo compatibility plugin is resolved separately. Add its repository to `pluginManagement` in `settings.gradle.kts`:
+
+```kotlin
+pluginManagement {
+    repositories {
+        maven {
+            url = uri("https://software.mobile.pendo.io/artifactory/cmp-beta/")
+        }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+```
+
+### Add Pendo to the shared module
+
+Add the CMP SDK to `commonMain` in the shared KMP module's `build.gradle.kts`:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api("com.pendo:pendo-cmp:3.14.0")
+        }
+    }
+}
+```
+
+Apply the Pendo compatibility plugin to the same shared KMP module:
+
+```kotlin
+plugins {
+    id("com.pendo.cmp.compat") version "3.14.0"
+}
+```
+
+> [!IMPORTANT]
+> The `com.pendo.cmp.compat` plugin version must exactly match the `com.pendo:pendo-cmp` version. The build fails when the versions don't match.
+
+The compatibility plugin enables automatic capture of Compose overlays such as dialogs and popups on iOS across supported Compose UI versions.
+
+### Export Pendo for iOS
+
+Export the CMP SDK from each iOS framework target:
+
+```kotlin
+listOf(
+    iosX64(),
+    iosArm64(),
+    iosSimulatorArm64(),
+).forEach { target ->
+    target.binaries.framework {
+        baseName = "Shared" // Use your framework name
+        isStatic = true
+        export("com.pendo:pendo-cmp:3.14.0")
+    }
+}
+```
+
+### Add the native Pendo iOS SDK
+
+The native Pendo iOS SDK must be installed separately.
+
+#### CocoaPods
+
+1. Open the `Podfile`.
+2. Add `pod 'Pendo', '~> 3.14.0'`.
+
+#### Swift Package Manager
+
+1. In Xcode, select **File > Add Package Dependencies**.
+2. Enter `https://github.com/pendo-io/pendo-mobile-sdk`.
+3. Select **Up to Next Minor Version** and a `3.14.x` version.
+
+No separate native SDK installation is required for Android.
+
+## Step 2. Connect to Pendo
+
+> [!NOTE]
+> Find your API key in the Pendo UI under **Settings > Subscription settings > select an app > App Details**.
+
+`Pendo.setup()` and `Pendo.setDebugMode()` are common CMP APIs and can be called from shared code. Call `setup()` once, as early as possible. Start a session whenever your app is ready to begin collecting activity:
+
+```kotlin
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.pendo.cmp.Pendo
+
+@Composable
+fun App() {
+    LaunchedEffect(Unit) {
+        Pendo.setDebugMode(true) // Use only while debugging
+        Pendo.setup("YOUR_API_KEY_HERE") // Call as early as possible
+
+        // Start the session here, or whenever appropriate for your app
+        Pendo.startSession(
+            visitorId = "VISITOR-UNIQUE-ID",
+            accountId = "ACCOUNT-UNIQUE-ID",
+            visitorData = mapOf("age" to 27, "country" to "USA"),
+            accountData = mapOf("Tier" to 1, "Size" to "Enterprise"),
+        )
+    }
+
+    MyAppContent()
+}
+```
+
+`Pendo.startSession()` ends any previous mobile session and starts a new session.
+
+> [!TIP]
+> To begin a session for an <a href="https://support.pendo.io/hc/en-us/articles/360032202751" target="_blank">anonymous visitor</a>, pass `null` as the visitor ID. You can call `startSession()` again to move from an anonymous session to an identified session or to switch visitors.
+
+## Step 3. Add PendoTracker
+
+Wrap your shared navigable content with [`PendoTracker`](/api-documentation/compose-multiplatform-apis.md#pendotracker) to enable Pendo tracking on both Android and iOS.
+
+### Jetpack Compose Navigation
+
+```kotlin
+import com.pendo.cmp.PendoTracker
+import com.pendo.cmp.nav.PendoNav2
+
+@Composable
+fun MyAppContent() {
+    val navController = rememberNavController()
+
+    PendoTracker(navigator = PendoNav2(navController)) {
+        NavHost(navController, startDestination = "home") {
+            composable("home") {
+                HomeScreen()
+            }
+        }
+    }
+}
+```
+
+### Slack Circuit
+
+```kotlin
+import com.pendo.cmp.PendoTracker
+import com.pendo.cmp.nav.PendoCircuit
+
+@Composable
+fun MyCircuitContent(circuit: Circuit) {
+    val backStack = rememberSaveableBackStack(root = HomeScreen)
+    val navigator = rememberCircuitNavigator(backStack)
+
+    PendoTracker(navigator = PendoCircuit(backStack)) {
+        CircuitCompositionLocals(circuit) {
+            NavigableCircuitContent(navigator, backStack)
+        }
+    }
+}
+```
+
+## Step 4. Configure Pairing Mode
+
+These steps enable page tagging and guide testing. Find your scheme ID in the Pendo UI under **Settings > Subscription settings > select an app > App Details**.
+
+### iOS
+
+In Xcode, go to **App Target > Info > URL Types** and add a URL type with:
+
+- **Identifier:** `pendo-pairing`
+- **URL Scheme:** your scheme ID from the Pendo UI
+
+Then forward the pairing deep link to Pendo.
+
+If your app uses the SwiftUI app lifecycle, add `onOpenURL` to its root content:
+
+```swift
+import Shared // Use your shared framework name
+
+WindowGroup {
+    ContentView()
+        .onOpenURL { url in
+            if url.scheme?.range(of: "pendo") != nil {
+                Pendo.shared.handleDeepLink(url: url.absoluteString)
+            }
+        }
+}
+```
+
+If your app uses `AppDelegate`, add or update the following method:
+
+```swift
+func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+) -> Bool {
+    if url.scheme?.range(of: "pendo") != nil {
+        Pendo.shared.handleDeepLink(url: url.absoluteString)
+        return true
+    }
+
+    return false
+}
+```
+
+If your app uses `SceneDelegate`, add or update the following method:
+
+```swift
+func scene(
+    _ scene: UIScene,
+    openURLContexts URLContexts: Set<UIOpenURLContext>
+) {
+    if let url = URLContexts.first?.url,
+       url.scheme?.range(of: "pendo") != nil {
+        Pendo.shared.handleDeepLink(url: url.absoluteString)
+    }
+}
+```
+
+### Android
+
+Add the Pendo pairing activity to `AndroidManifest.xml`:
+
+```xml
+<activity
+    android:name="sdk.pendo.io.activities.PendoGateActivity"
+    android:launchMode="singleInstance"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="YOUR_SCHEME_ID_HERE"/>
+    </intent-filter>
+</activity>
+```
+
+## Step 5. Add drawer and bottom sheet support
+
+To track a Compose drawer or bottom sheet, add [`Modifier.pendoStateModifier()`](/api-documentation/compose-multiplatform-apis.md#pendostatemodifier) with the component's state.
+
+### Drawer
+
+```kotlin
+@Composable
+fun AppDrawer() {
+    val drawerState = rememberDrawerState(DrawerValue.Closed)
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        modifier = Modifier.pendoStateModifier(drawerState),
+        drawerContent = {
+            // Drawer content
+        },
+    ) {
+        // App content
+    }
+}
+```
+
+### Bottom sheet
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppBottomSheet() {
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        sheetState = sheetState,
+        modifier = Modifier.pendoStateModifier(sheetState),
+        onDismissRequest = {
+            scope.launch {
+                sheetState.hide()
+            }
+        },
+    ) {
+        // Sheet content
+    }
+}
+```
+
+Update the drawer or sheet state when the component is dismissed so Pendo stops detecting it as the current page.
+
+## Step 6. Identify elements and custom screens
+
+Use [`Modifier.pendoTag()`](/api-documentation/compose-multiplatform-apis.md#pendotag) to give an element a stable identifier that doesn't depend on its displayed text:
+
+```kotlin
+import com.pendo.cmp.pendoTag
+
+Button(
+    modifier = Modifier.pendoTag(
+        tag = "checkout_button",
+        mergeDescendants = true,
+    ),
+    onClick = ::checkout,
+) {
+    Text("Checkout")
+}
+```
+
+Use [`Modifier.pendoScreenId()`](/api-documentation/compose-multiplatform-apis.md#pendoscreenid) for tabs or other state-driven content that doesn't have its own navigation route:
+
+```kotlin
+import com.pendo.cmp.pendoScreenId
+
+Box(
+    modifier = Modifier.pendoScreenId("ProfileTab"),
+) {
+    ProfileContent()
+}
+```
+
+## Step 7. Verify the installation
+
+1. Run the app.
+2. Look for the log message: `Pendo Mobile SDK was successfully integrated and connected to the server.`
+3. In the Pendo UI, go to **Settings > Subscription Settings** and select your app.
+4. Open the **Install Settings** tab and complete **Verify Your Installation**.
+5. Confirm that the app is shown as **Integrated**.
+
+## Known limitations
+
+- Automatic navigation tracking supports Jetpack Compose Navigation (Navigation 2) and Slack Circuit. Other navigation libraries, including Navigation 3, Voyager, and Decompose, aren't currently supported.
+- Drawers and bottom sheets require `Modifier.pendoStateModifier()` for state tracking.
+- Compose UI versions through `1.12` are supported. Future Pendo CMP releases will add support for newer Compose UI versions.
+- The native Pendo iOS SDK must use the same major and minor version as the CMP SDK.
+
+## Developer documentation
+
+- [Compose Multiplatform API documentation](/api-documentation/compose-multiplatform-apis.md)
+
+## Troubleshooting
+
+- For technical issues, [review open issues](https://github.com/pendo-io/pendo-mobile-sdk/issues) or [submit a new issue](https://github.com/pendo-io/pendo-mobile-sdk/issues).
+- See the [Pendo Mobile SDK release notes](https://developers.pendo.io/category/mobile-sdk/).


### PR DESCRIPTION
## Summary
- add a customer-facing Compose Multiplatform 3.14 integration guide for Android and iOS
- document dependency setup, compatibility plugin alignment, navigation tracking, Pairing Mode, overlays, verification, Session Replay, and limitations
- organize KMP navigation so Native UI and Compose Multiplatform appear together and cross-link the two guides

## Dependency
- stacked on the KMP native UI documentation in #360

## Test plan
- [x] Validate documented APIs and requirements against the CMP SDK source and internal integration guide
- [x] Check Markdown structure, links, code fences, and whitespace
- [ ] Review the rendered guide on GitHub

Jira: [APP-163829](https://pendo-io.atlassian.net/browse/APP-163829)

[APP-163829]: https://pendo-io.atlassian.net/browse/APP-163829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ