### PR TITLE
APP-164010 doc: note debug-only manifest option for PendoGateActivity (Android)

### DIFF
--- a/android/pnddocs/flutter-android.md
+++ b/android/pnddocs/flutter-android.md
@@ -244,6 +244,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 4. Verify installation
 
 1. Test using Android Studio:  

--- a/android/pnddocs/native-android.md
+++ b/android/pnddocs/native-android.md
@@ -205,6 +205,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 5. Verify installation
 
 1. Test using Android Studio:  

--- a/android/pnddocs/rn-android.md
+++ b/android/pnddocs/rn-android.md
@@ -174,6 +174,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 4. Verify installation
 
 1. Test using Android Studio:  

--- a/android/pnddocs/rnn-android.md
+++ b/android/pnddocs/rnn-android.md
@@ -153,6 +153,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 4. Verify installation
 
 1. Test using Android Studio:  

--- a/android/pnddocs/xamarin_forms-android.md
+++ b/android/pnddocs/xamarin_forms-android.md
@@ -132,6 +132,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 4. Verify installation
 
 1. Test using Visual Studio:  

--- a/android/pnddocs/xamarin_maui-android.md
+++ b/android/pnddocs/xamarin_maui-android.md
@@ -155,6 +155,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ## Step 4. Verify installation
 1. Test using Visual Studio:  
 Run the app.  

--- a/other/native-with-flutter-components.md
+++ b/other/native-with-flutter-components.md
@@ -183,6 +183,9 @@ Add the following **activity** to the application **AndroidManifest.xml** in the
 </activity>
 ```
 
+> [!NOTE]
+> This activity is used only by Pendo's pairing mode for page tagging and on-device guide testing. It is not required by your production app. To exclude it from release builds, declare it in the debug-only manifest (`src/debug/AndroidManifest.xml`) instead of the main manifest. In this configuration, Pendo users—such as product managers—must use a debug build to tag pages or test guides on a device; pairing will not be available in the production app.
+
 ### Step 4. Verify installation
 
 1. Test using Android Studio:  


### PR DESCRIPTION
## Summary

Addresses Data Theorem finding **213** ("App Vulnerable to Pixnapping") flagged on the exported `sdk.pendo.io.activities.PendoGateActivity`. The activity is exported in customer APKs only because our own install guides tell customers to register it that way — the SDK manifest itself does not export it.

Rather than changing the documented default, this PR keeps the existing instructions and adds a `> [!NOTE]` callout after each `PendoGateActivity` manifest block explaining that:
- the activity is only used by Pendo's pairing mode (page tagging + on-device guide testing) and isn't required in production, and
- customers who prefer not to expose it in release builds can place it in a debug-only manifest (`src/debug/AndroidManifest.xml`), at the cost of pairing being unavailable in release builds.

This closes the finding across the customer base rather than answering it one customer at a time. See [APP-164010](https://pendo-io.atlassian.net/browse/APP-164010).

## Files changed

| File | Change |
|------|--------|
| `android/pnddocs/native-android.md` | Add debug-manifest note |
| `android/pnddocs/rn-android.md` | Add debug-manifest note |
| `android/pnddocs/rnn-android.md` | Add debug-manifest note |
| `android/pnddocs/flutter-android.md` | Add debug-manifest note |
| `android/pnddocs/xamarin_forms-android.md` | Add debug-manifest note |
| `android/pnddocs/xamarin_maui-android.md` | Add debug-manifest note |
| `other/native-with-flutter-components.md` | Add debug-manifest note |

## Notes

- Expo Android guides configure the scheme via the Expo config plugin (`android-scheme` in `app.json`) rather than a manual exported activity, so no change was needed there.
- The Compose Multiplatform and KMP guides receive the same note on their in-flight branch (PR #356), since those files are not yet on `master`.
- Coordinated with the iOS counterpart APP-164000 (DT finding 116 / CVE-2026-26123).

[APP-164010]: https://pendo-io.atlassian.net/browse/APP-164010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ