### PR TITLE
APP-165741 [CMP][Docs] Document PrivacyAction.NONE

### DIFF
--- a/api-documentation/compose-multiplatform-apis.md
+++ b/api-documentation/compose-multiplatform-apis.md
@@ -39,7 +39,6 @@ Core APIs and modifiers are available from `com.pendo.cmp`. Navigation adapters 
 - [`pendoScreenId`](#pendoscreenid)
 - [`pendoStateModifier`](#pendostatemodifier)
 - [`applyPendoSRPrivacy`](#applypendosrprivacy)
-- [`clearPendoSRPrivacy`](#clearpendosrprivacy)
 - [`PrivacyAction`](#privacyaction)
 
 ## Pendo APIs
@@ -478,19 +477,11 @@ TextField(
 )
 ```
 
-### `clearPendoSRPrivacy`
-
-```kotlin
-fun Modifier.clearPendoSRPrivacy(): Modifier
-```
-
-Clears the privacy action on an element so it uses inherited or configured Session Replay behavior.
-
-Use this modifier by itself. Do not chain it after `applyPendoSRPrivacy()` on the same element.
+To clear a previously applied privacy action so the element uses inherited or configured Session Replay behavior, apply `PrivacyAction.NONE`. Use it by itself. Do not chain it after another `applyPendoSRPrivacy()` on the same element.
 
 ```kotlin
 Text(
-    modifier = Modifier.clearPendoSRPrivacy(),
+    modifier = Modifier.applyPendoSRPrivacy(PrivacyAction.NONE),
     text = "Public content",
 )
 ```
@@ -502,6 +493,7 @@ enum class PrivacyAction {
     MASK,
     UNMASK,
     BLOCK,
+    NONE,
 }
 ```
 
@@ -510,5 +502,6 @@ enum class PrivacyAction {
 | `MASK` | Redacts text. It does not affect images or other non-text content. |
 | `UNMASK` | Reveals non-sensitive text that would otherwise be masked. Password fields remain masked. |
 | `BLOCK` | Replaces the element and its descendants with a placeholder and excludes interactions within its bounds. |
+| `NONE` | Removes the element's own privacy action so it uses inherited or configured Session Replay behavior. It is not the same as `UNMASK`. |
 
 Compose cannot automatically identify email and phone fields as sensitive. Avoid `UNMASK` on those fields, or protect them with password semantics.


### PR DESCRIPTION
## Summary
Updates the Compose Multiplatform Session Replay privacy docs (`api-documentation/compose-multiplatform-apis.md`) to reflect the API change in [cmp-pendo-sdk #77](https://github.com/pendo-io/cmp-pendo-sdk/pull/77) (APP-165740):

- Removes the standalone `clearPendoSRPrivacy` section and its table-of-contents entry.
- Folds the clear guidance into `applyPendoSRPrivacy`: apply `PrivacyAction.NONE` by itself to reset an element to inherited/configured behavior (do not chain it after another `applyPendoSRPrivacy()`).
- Adds `NONE` to the `PrivacyAction` enum block and the behavior table, noting it is not the same as `UNMASK`.

No behavior change — `PrivacyAction.NONE` resolves exactly as the old `clearPendoSRPrivacy()` did.

## Base branch
Targets `APP-161055_add-kmp-integration-docs`, the branch that introduces the CMP API docs page (the page does not yet exist on `main`), matching the per-platform SR-privacy docs branch pattern.

## Test plan
- [x] `clearPendoSRPrivacy` no longer referenced on the CMP page.
- [x] TOC, `applyPendoSRPrivacy` example, and `PrivacyAction` enum/table all show `NONE`.