### PR TITLE
Revert "APP-164000 Clarify that the iOS pairing URL scheme includes the pendo- prefix"

### DIFF
--- a/ios/pnddocs/flutter-ios.md
+++ b/ios/pnddocs/flutter-ios.md
@@ -229,9 +229,6 @@ These steps enable  <a href="https://support.pendo.io/hc/en-us/articles/36003348
    Set **Identifier** to pendo-pairing or any name of your choosing.  
    Set **URL Scheme** to `YOUR_SCHEME_ID_HERE`.
 
-   >[!IMPORTANT]
-   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging">
 
 2. **To enable pairing from the device:**

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -170,9 +170,6 @@ Navigate to your **App Target > Info > URL Types** and create a new URL by click
 Set the **Identifier** to `pendo-pairing` or an identifiable name of your choosing.  
 Set **URL Scheme** to `YOUR_SCHEME_ID_HERE`.
 
->[!IMPORTANT]
->Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
 <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging">
 
 ### Configure the app to connect to Pairing Mode

--- a/ios/pnddocs/rn-ios.md
+++ b/ios/pnddocs/rn-ios.md
@@ -161,9 +161,6 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
       Set **Identifier** to pendo-pairing or any name of your choosing.  
       Set **URL Scheme** to `YOUR_SCHEME_ID`.
 
-      >[!IMPORTANT]
-      >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging"/> <br>
 
 2. To enable pairing from the device:

--- a/ios/pnddocs/rnn-ios.md
+++ b/ios/pnddocs/rnn-ios.md
@@ -140,9 +140,6 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
       Set **Identifier** to pendo-pairing or any name of your choosing.  
       Set **URL Scheme** to `YOUR_SCHEME_ID`.
 
-      >[!IMPORTANT]
-      >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging"/> <br>
 
 2. To enable pairing from the device:

--- a/ios/pnddocs/xamarin_forms-ios.md
+++ b/ios/pnddocs/xamarin_forms-ios.md
@@ -123,9 +123,6 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
     - `URL identifier` of type `String` with a value that begins with `pendo` (ex. `pendo-scheme-d`).
     - `URL Schemes` of type `Array`. Add a `String` item with `YOUR_SCHEME_ID` as the value.
 
-   >[!IMPORTANT]
-   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
 2. Add or modify the function **OpenURL**:
 
    Open ***AppDelegate.cs*** file and the following code:

--- a/ios/pnddocs/xamarin_maui-ios.md
+++ b/ios/pnddocs/xamarin_maui-ios.md
@@ -142,9 +142,6 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
     - `URL identifier` of type `String` with a value that begins with `pendo` (ex. `pendo-scheme-d`).
     - `URL Schemes` of type `Array`. Add a `String` item with `YOUR_SCHEME_ID` as the value.
 
-   >[!IMPORTANT]
-   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
-
 2. Add or modify the function **OpenURL**:
 
    Open ***AppDelegate.cs*** file and add ***using PendoMaui;*** 


### PR DESCRIPTION
Reverts #364.

This reverts the `[!IMPORTANT]` note about the `pendo-` prefix added to the six iOS install guides (`native-ios.md`, `flutter-ios.md`, `rn-ios.md`, `rnn-ios.md`, `xamarin_forms-ios.md`, `xamarin_maui-ios.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)