### PR TITLE
APP-164000 Clarify that the iOS pairing URL scheme includes the pendo- prefix

### DIFF
--- a/ios/pnddocs/flutter-ios.md
+++ b/ios/pnddocs/flutter-ios.md
@@ -229,6 +229,9 @@ These steps enable  <a href="https://support.pendo.io/hc/en-us/articles/36003348
    Set **Identifier** to pendo-pairing or any name of your choosing.  
    Set **URL Scheme** to `YOUR_SCHEME_ID_HERE`.
 
+   >[!IMPORTANT]
+   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging">
 
 2. **To enable pairing from the device:**

--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -170,6 +170,9 @@ Navigate to your **App Target > Info > URL Types** and create a new URL by click
 Set the **Identifier** to `pendo-pairing` or an identifiable name of your choosing.  
 Set **URL Scheme** to `YOUR_SCHEME_ID_HERE`.
 
+>[!IMPORTANT]
+>Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
 <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging">
 
 ### Configure the app to connect to Pairing Mode

--- a/ios/pnddocs/rn-ios.md
+++ b/ios/pnddocs/rn-ios.md
@@ -161,6 +161,9 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
       Set **Identifier** to pendo-pairing or any name of your choosing.  
       Set **URL Scheme** to `YOUR_SCHEME_ID`.
 
+      >[!IMPORTANT]
+      >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging"/> <br>
 
 2. To enable pairing from the device:

--- a/ios/pnddocs/rnn-ios.md
+++ b/ios/pnddocs/rnn-ios.md
@@ -140,6 +140,9 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
       Set **Identifier** to pendo-pairing or any name of your choosing.  
       Set **URL Scheme** to `YOUR_SCHEME_ID`.
 
+      >[!IMPORTANT]
+      >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
     <img src="https://user-images.githubusercontent.com/56674958/144723345-15c54098-28db-414c-90da-ef4a5256ae6a.png" width="500" height="300" alt="Mobile Tagging"/> <br>
 
 2. To enable pairing from the device:

--- a/ios/pnddocs/xamarin_forms-ios.md
+++ b/ios/pnddocs/xamarin_forms-ios.md
@@ -123,6 +123,9 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
     - `URL identifier` of type `String` with a value that begins with `pendo` (ex. `pendo-scheme-d`).
     - `URL Schemes` of type `Array`. Add a `String` item with `YOUR_SCHEME_ID` as the value.
 
+   >[!IMPORTANT]
+   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
 2. Add or modify the function **OpenURL**:
 
    Open ***AppDelegate.cs*** file and the following code:

--- a/ios/pnddocs/xamarin_maui-ios.md
+++ b/ios/pnddocs/xamarin_maui-ios.md
@@ -142,6 +142,9 @@ and <a href="https://support.pendo.io/hc/en-us/articles/360033487792-Creating-a-
     - `URL identifier` of type `String` with a value that begins with `pendo` (ex. `pendo-scheme-d`).
     - `URL Schemes` of type `Array`. Add a `String` item with `YOUR_SCHEME_ID` as the value.
 
+   >[!IMPORTANT]
+   >Use the complete scheme ID exactly as it appears in Subscription settings, including the `pendo-` prefix (for example, `pendo-a1b2c3d4`). From SDK `3.14`, pairing links whose scheme does not start with `pendo-`, or does not match a scheme registered here, are rejected.
+
 2. Add or modify the function **OpenURL**:
 
    Open ***AppDelegate.cs*** file and add ***using PendoMaui;*** 


### PR DESCRIPTION
**Docs only.** Makes explicit that the iOS `Info.plist` **URL Scheme** value must be the complete scheme ID from Subscription settings, including its `pendo-` prefix.

## Why

All six iOS install guides currently say some variant of *"Set **URL Scheme** to `YOUR_SCHEME_ID`"* without stating that the value carries a `pendo-` prefix. The only `pendo-` example in the docs — `pendo-scheme-d` in the Xamarin guides — is for the **URL identifier**, which is just a label the SDK never reads. So nothing anywhere states the requirement.

From SDK `3.14`, `PNDWSPairingManager verifyPairingURL:` rejects a pairing link whose scheme is not `pendo-` prefixed or does not match a scheme registered in the app's own `Info.plist` (pendo-io/Insert-iOS-SDK#2569). Spelling the requirement out where customers actually set the value.

## What changed

The same `[!IMPORTANT]` note added next to the URL Scheme instruction in:

- `ios/pnddocs/native-ios.md`
- `ios/pnddocs/flutter-ios.md`
- `ios/pnddocs/rn-ios.md`
- `ios/pnddocs/rnn-ios.md`
- `ios/pnddocs/xamarin_forms-ios.md`
- `ios/pnddocs/xamarin_maui-ios.md`

## Not a breaking change

Every real registered scheme we could find already carries the prefix — `pendo-7c301e95`, `pendo-89f4201b` (UIKitCatalog), `pendo-0861c1ce`, `pendo-94903f5a` (a customer app). Subscription settings hands out the prefixed value and customers paste it whole, so existing integrations are unaffected. This is a clarification, not a migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)