### PR TITLE
APP-166730 Document Navigation 3 support in the CMP guide

### DIFF
--- a/api-documentation/compose-multiplatform-apis.md
+++ b/api-documentation/compose-multiplatform-apis.md
@@ -34,6 +34,7 @@ Core APIs and modifiers are available from `com.pendo.cmp`. Navigation adapters 
 - [`PendoTracker`](#pendotracker)
 - [`PendoNavigator`](#pendonavigator)
 - [`PendoNav2`](#pendonav2)
+- [`PendoNav3`](#pendonav3)
 - [`PendoCircuit`](#pendocircuit)
 - [`pendoTag`](#pendotag)
 - [`pendoScreenId`](#pendoscreenid)
@@ -334,7 +335,7 @@ PendoTracker(navigator = PendoNav2(navController)) {
 sealed interface PendoNavigator
 ```
 
-Represents a supported navigation adapter for `PendoTracker`. Use `PendoNav2` for Jetpack Compose Navigation 2 or `PendoCircuit` for Slack Circuit.
+Represents a supported navigation adapter for `PendoTracker`. Use `PendoNav2` for Jetpack Compose Navigation 2, `PendoNav3` for Jetpack Navigation 3, or `PendoCircuit` for Slack Circuit.
 
 ### `PendoNav2`
 
@@ -351,6 +352,22 @@ PendoTracker(navigator = PendoNav2(navController)) {
     NavHost(navController, startDestination = "home") {
         // Destinations
     }
+}
+```
+
+### `PendoNav3`
+
+```kotlin
+class PendoNav3(
+    val backStack: List<Any>,
+) : PendoNavigator
+```
+
+Adapts a Jetpack Navigation 3 back stack for `PendoTracker`. The back stack must be snapshot-backed, such as `rememberNavBackStack(...)` or `mutableStateListOf(...)`. The screen is identified by the top key's class name.
+
+```kotlin
+PendoTracker(navigator = PendoNav3(backStack)) {
+    NavDisplay(backStack = backStack, entryProvider = entryProvider { /* Entries */ })
 }
 ```
 

--- a/other/compose-multiplatform.md
+++ b/other/compose-multiplatform.md
@@ -17,6 +17,7 @@
 >
 > Supported navigation libraries:
 > - Jetpack Compose Navigation (Navigation 2)
+> - Jetpack Navigation 3
 > - Slack Circuit `0.20.0` or higher
 
 ## Step 1. Add the Pendo CMP SDK
@@ -66,7 +67,7 @@ Add the CMP SDK to `commonMain` in the shared KMP module's `build.gradle.kts`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api("com.pendo:pendo-cmp:3.14.0")
+            api("com.pendo:pendo-cmp:3.14.1")
         }
     }
 }
@@ -76,7 +77,7 @@ Apply the Pendo compatibility plugin to the same shared KMP module:
 
 ```kotlin
 plugins {
-    id("com.pendo.cmp.compat") version "3.14.0"
+    id("com.pendo.cmp.compat") version "3.14.1"
 }
 ```
 
@@ -98,7 +99,7 @@ listOf(
     target.binaries.framework {
         baseName = "Shared" // Use your framework name
         isStatic = true
-        export("com.pendo:pendo-cmp:3.14.0")
+        export("com.pendo:pendo-cmp:3.14.1")
     }
 }
 ```
@@ -110,7 +111,7 @@ The native Pendo iOS SDK must be installed separately.
 #### CocoaPods
 
 1. Open the `Podfile`.
-2. Add `pod 'Pendo', '~> 3.14.0'`.
+2. Add `pod 'Pendo', '~> 3.14.1'`.
 
 #### Swift Package Manager
 
@@ -179,6 +180,38 @@ fun MyAppContent() {
     }
 }
 ```
+
+### Jetpack Navigation 3
+
+```kotlin
+import com.pendo.cmp.PendoTracker
+import com.pendo.cmp.nav.PendoNav3
+
+@Composable
+fun MyAppContent() {
+    val backStack = rememberNavBackStack(HomeKey)
+
+    PendoTracker(navigator = PendoNav3(backStack)) {
+        NavDisplay(
+            backStack = backStack,
+            entryProvider = entryProvider {
+                entry<HomeKey> {
+                    HomeScreen()
+                }
+            }
+        )
+    }
+}
+```
+
+The screen is identified by the top back-stack key's class name (`HomeKey`), so key arguments
+don't create separate screens: `DetailKey("42")` and `DetailKey("43")` are the same screen. Pass a
+snapshot-backed back stack — `rememberNavBackStack(...)` or `mutableStateListOf(...)` — otherwise
+only the initial screen is reported.
+
+Pendo Android SDK `3.14.1` or higher reports the same key on Android, including for an adaptive
+scene that displays two entries side by side. Earlier Android SDK versions identify such a scene by
+every entry it displays, which doesn't match the screen reported on iOS.
 
 ### Slack Circuit
 
@@ -367,7 +400,7 @@ Box(
 
 ## Known limitations
 
-- Automatic navigation tracking supports Jetpack Compose Navigation (Navigation 2) and Slack Circuit. Other navigation libraries, including Navigation 3, Voyager, and Decompose, aren't currently supported.
+- Automatic navigation tracking supports Jetpack Compose Navigation (Navigation 2), Jetpack Navigation 3, and Slack Circuit. Other navigation libraries, including Voyager and Decompose, aren't currently supported.
 - Drawers and bottom sheets require `Modifier.pendoStateModifier()` for state tracking.
 - Compose UI versions through `1.12` are supported. Future Pendo CMP releases will add support for newer Compose UI versions.
 - The native Pendo iOS SDK must use the same major and minor version as the CMP SDK.


### PR DESCRIPTION
[APP-166730](https://pendo-io.atlassian.net/browse/APP-166730)

> [!IMPORTANT]
> Draft on purpose — **merge only once CMP SDK `3.14.1` is released.** The text and the install snippets describe 3.14.1 as available.

Navigation 3 joins Navigation 2 and Circuit as a supported navigation library for the CMP SDK.

## `other/compose-multiplatform.md`

- Requirements → adds Jetpack Navigation 3 to the supported navigation libraries.
- New **Jetpack Navigation 3** section between the Navigation 2 and Circuit examples, showing `PendoTracker(navigator = PendoNav3(backStack))` around `NavDisplay`.
- Known Limitations → Navigation 3 removed from the unsupported list; Voyager and Decompose remain.
- Install snippets move `3.14.0` → `3.14.1` (Gradle `api`, the `com.pendo.cmp.compat` plugin, the iOS framework `export`, and the CocoaPods pin).

Two things the example states because they change what customers see, rather than leaving them to discover it:

- **What identifies the screen** — the top back-stack key's class name, so `DetailKey("42")` and `DetailKey("43")` are one screen rather than two.
- **The back stack must be snapshot-backed** (`rememberNavBackStack(...)` / `mutableStateListOf(...)`); a plain list reports only the initial screen, since there is nothing to observe.

It also names the Pendo Android SDK floor:

> Pendo Android SDK `3.14.1` or higher reports the same key on Android, including for an adaptive scene that displays two entries side by side. Earlier Android SDK versions identify such a scene by every entry it displays, which doesn't match the screen reported on iOS.

That floor isn't enforced at runtime — the CMP SDK validates the iOS SDK version only — so a customer on an older Android SDK gets differing screens across platforms with no warning.

## `api-documentation/compose-multiplatform-apis.md`

- `PendoNav3` added to the API index, to the `PendoNavigator` description, and as its own entry between `PendoNav2` and `PendoCircuit`.

## Related

- pendo-io/cmp-pendo-sdk#78 — CMP-side support (APP-162967)
- pendo-io/Insert-Android-SDK#3096 — Android side, so a CMP app reports the same screen name on both platforms (APP-166472)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-166730]: https://pendo-io.atlassian.net/browse/APP-166730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ