### PR TITLE
APP-168912 Document iOS 27 support in native-ios.md

### DIFF
--- a/ios/pnddocs/native-ios.md
+++ b/ios/pnddocs/native-ios.md
@@ -21,6 +21,9 @@
 >[!IMPORTANT]
 ><b>SwiftUI</b> codeless solution is fully supported from `iOS 15`. <br/> <b>SwiftUI</b> screen navigation tracking is available from `iOS 13`.
 
+>[!NOTE]
+>iOS 27 support requires SDK `3.14.4` or later. Earlier SDK versions may fail to match some navigation bar and iPad sidebar tags after upgrading to iOS 27.
+
 >[!IMPORTANT]
 >Requirements:
 >- Deployment target of `iOS 11` or higher 


### PR DESCRIPTION
## What

Adds a `NOTE` callout to `ios/pnddocs/native-ios.md` announcing iOS 27 support:

>**iOS 27 support.** `iOS 27` is supported from SDK `3.14.4`. On earlier versions some navigation-bar and iPad sidebar tags stop matching on iOS 27 - upgrade to `3.14.4` or higher.

Placed after the SwiftUI callout and before the Requirements callout. `NOTE` rather than `IMPORTANT` because the file already opens with two `IMPORTANT` callouts.

## Why

The doc had no statement that iOS 27 is supported. It also needs to carry the upgrade consequence — on SDK versions before `3.14.4`, iOS 27 changes the accessibility identifiers of navigation-bar items and the iPad split-view sidebar toggle, so tags bound to those stop matching. Saying "iOS 27 is supported" without that would be true for `3.14.4` users and quietly wrong for everyone else.

Fixes referenced: APP-168211 (bar-item identifier), APP-168080 (iPad sidebar toggle), APP-168242 (SwiftUI toolbar layer node).

## Verification

Full iOS 26.5 (`23F77`) vs iOS 27.0 RC (`24A434`) run on 2026-09-10 against tag `v3.14.4.12685`, iPhone 17 Pro and iPad Pro 13" M5 (model-matched, same binary on both OSes):

| Check | iPhone | iPad |
|---|---|---|
| Build gate | 29 deprecations, same as every beta | same |
| Unit suites | 7/7 matched, 0 restarts | 7/7 matched, 0 restarts |
| Analytics identifiers | 1 lost / 1 gained | same two |
| Pairing FE tree | no clickable predicate lost | no clickable predicate lost |
| Guide rendering | 76/76, 0 not shown | 76/76, 0 not shown |

`c70a058d` (`sidebar.leading`) now matches 20x/20x across the OS boundary and `d22e9eda` (`swirl.circle.righthalf.filled`) survives on both — i.e. the `3.14.4` fixes hold on the RC, which is what this doc change claims.

## Reviewer note

Please confirm the public `3.14.4` release is the build carrying APP-168080, APP-168211 and APP-168242 before merging. I verified those branches merged into `v3.14.4.12685` in Insert-iOS-SDK and that tag `3.14.4` exists here, but not that they are the same build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)